### PR TITLE
initial commit of ds1963s plugins + various other fixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/plugins/ds1963s_in_ds2480b/ds1963s-utils"]
+	path = src/plugins/ds1963s_in_ds2480b/ds1963s-utils
+	url = https://github.com/rhuizer/ds1963s-utils.git

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ loader:
 	cc -shared -m32 -fPIC src/piutools_loader.c $(PLUGIN_INCLUDES) -ldl -o $(BUILD_ROOT)/piutools.so
 
 # --- Plugins ---
-plugins: asound.plugin  ata_hdd.plugin microdog_34.plugin s3d_opengl.plugin deadlock.plugin  filesystem_redirect.plugin ticket_dispenser.plugin usbfs_null.plugin io_x11_ckdur.plugin
+plugins: asound.plugin  ata_hdd.plugin microdog_34.plugin s3d_opengl.plugin deadlock.plugin ds1963s_in_ds2480b.plugin filesystem_redirect.plugin ticket_dispenser.plugin usbfs_null.plugin io_x11_ckdur.plugin
 
 asound.plugin:
 	cc -shared -m32 -fPIC src/plugins/asound/asound.c $(PLUGIN_INCLUDES) -o $(PLUGIN_BUILD_ROOT)/$@
@@ -22,6 +22,20 @@ ata_hdd.plugin:
 
 deadlock.plugin:
 	cc -shared -m32 -fPIC src/plugins/deadlock/deadlock.c $(PLUGIN_INCLUDES) -o $(PLUGIN_BUILD_ROOT)/$@
+
+DS1963S_UTILS_SOURCES := src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/1-wire-bus.c \
+						 src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/coroutine.c \
+						 src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ds1963s-common.c \
+						 src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ds1963s-device.c \
+						 src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ds2480b-device.c \
+						 src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/sha1.c \
+						 src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/transport-factory.c \
+						 src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/transport-pty.c \
+						 src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/transport.c
+
+ds1963s_in_ds2480b.plugin:
+	git submodule update --init --recursive # TODO: un-cheese
+	cc -shared -m32 -fPIC src/plugins/ds1963s_in_ds2480b/ds1963s_in_ds2480b.c $(DS1963S_UTILS_SOURCES) $(PLUGIN_INCLUDES) -lpthread -I src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src -o $(PLUGIN_BUILD_ROOT)/$@
 
 exec_blocker.plugin:
 	cc -shared -m32 -fPIC src/plugins/exec_blocker/exec_blocker.c $(PLUGIN_INCLUDES) -o $(PLUGIN_BUILD_ROOT)/$@

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ loader:
 	cc -shared -m32 -fPIC src/piutools_loader.c $(PLUGIN_INCLUDES) -ldl -o $(BUILD_ROOT)/piutools.so
 
 # --- Plugins ---
-plugins: asound.plugin  ata_hdd.plugin microdog_34.plugin s3d_opengl.plugin deadlock.plugin ds1963s_in_ds2480b.plugin filesystem_redirect.plugin ticket_dispenser.plugin usbfs_null.plugin io_x11_ckdur.plugin
+plugins: asound.plugin  ata_hdd.plugin microdog.plugin s3d_opengl.plugin deadlock.plugin ds1963s_in_ds2480b.plugin filesystem_redirect.plugin ticket_dispenser.plugin usbfs_null.plugin x11_keyboard_input.plugin
 
 asound.plugin:
 	cc -shared -m32 -fPIC src/plugins/asound/asound.c $(PLUGIN_INCLUDES) -o $(PLUGIN_BUILD_ROOT)/$@
@@ -31,6 +31,7 @@ DS1963S_UTILS_SOURCES := src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/1-wire
 						 src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/sha1.c \
 						 src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/transport-factory.c \
 						 src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/transport-pty.c \
+						 src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/transport-unix.c \
 						 src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/transport.c
 
 ds1963s_in_ds2480b.plugin:
@@ -65,7 +66,7 @@ fake_libusb.plugin:
 	cc -shared -m32 -fPIC src/plugins/fake_libusb/*.c $(PLUGIN_INCLUDES) -o $(PLUGIN_BUILD_ROOT)/$@
 
 microdog.plugin:
-	cc -shared -m32 $(PLUGIN_INCLUDES) src/plugins/microdog/microdog/*.c -I src/plugins/microdog/microdog src/plugins/microdog/microdog.c -o $(PLUGIN_BUILD_ROOT)/$@
+	cc -shared -m32 -fPIC $(PLUGIN_INCLUDES) src/plugins/microdog/microdog/*.c -I src/plugins/microdog/microdog src/plugins/microdog/microdog.c -o $(PLUGIN_BUILD_ROOT)/$@
 
 s3d_opengl.plugin:
 	cc -shared -m32 -fPIC src/plugins/s3d_opengl/s3d_opengl.c $(PLUGIN_INCLUDES) -o $(PLUGIN_BUILD_ROOT)/$@

--- a/run_loader.sh
+++ b/run_loader.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -euo pipefail
+
+# Runs the bare loader for debugging purposes
+
+usage() {
+    echo "Usage: $0 <game name> <game version> <command> [command args]"
+    echo "e.g.:"
+    echo -e "\t$0 pro1 r5 ./piu"
+    echo -e "\t$0 nx 108 gdb ./piu"
+    echo -e "\t$0 nx2 120 strace -e open ./piu"
+    exit 2
+}
+
+[[ $# -lt 2 ]] && usage
+
+PIUTOOLS_GAME_NAME="$1"
+shift
+PIUTOOLS_GAME_VERSION="$1"
+shift
+
+export DBGLOG=1
+export PIUTOOLS_GAME_NAME PIUTOOLS_GAME_VERSION
+export PIUTOOLS_PATH="$(readlink -f $(dirname $0))/build"
+export PIUTOOLS_CONFIG_PATH="${PIUTOOLS_PATH}/config"
+export PIUTOOLS_SAVE_PATH="${PIUTOOLS_PATH}/save"
+export PIUTOOLS_PLUGIN_PATH="${PIUTOOLS_PATH}/plugins"
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-""}:${PIUTOOLS_PATH}/libs"
+LD_PRELOAD="${PIUTOOLS_PATH}/piutools.so" "$@"

--- a/src/piutools_loader.c
+++ b/src/piutools_loader.c
@@ -27,7 +27,10 @@ static int get_function_address(const char* library_name, const char* function_n
     
     // Open our library or die.
     void* hLibrary = dlopen(library_name, RTLD_NOW);
-    if(hLibrary == NULL){return 0;}
+    if (hLibrary == NULL) {
+        fprintf(stderr, "%s: dlopen(): %s\n", __FUNCTION__, dlerror());
+        return 0;
+    }
     // Resolve our Symbol
     *pfunction_address = dlsym(hLibrary,function_name);
     // If we didn't resolve our symbol - die.
@@ -85,6 +88,8 @@ void load_plugin(const char* plugin_name){
             // Move to the next entry
             cur_entry++;
         }
+    } else {
+        DBG_printf("[%s] %s: no hook entries\n", __FUNCTION__, plugin_name);
     }
 }
 

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s_in_ds2480b.c
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s_in_ds2480b.c
@@ -1,0 +1,107 @@
+/*
+ * ds1963s_in_ds2480b.c -- emulates a Dallas Semiconductor DS1963S
+ * iButton in DS2480b (serial) housing
+ */
+
+#include <pthread.h>
+#include <stdlib.h>
+#include <string.h>
+#include <termios.h>
+#include "plugin_sdk/plugin.h"
+#include "plugin_sdk/dbg.h"
+#include "ds1963s-device.h"
+#include "ds2480b-device.h"
+#include "transport-factory.h"
+#include "transport-pty.h"
+
+#define DEFAULT_SERIAL_DEVICE "/dev/ttyS0"
+
+/* file ops */
+typedef int (*open_func_t)(const char *, int);
+open_func_t next_open;
+
+/*
+typedef int (*close_func_t)(int);
+close_func_t next_close;
+typedef ssize_t (*read_func_t)(int, void *, size_t);
+read_func_t next_read;
+typedef ssize_t (*write_func_t)(int, void *, size_t);
+write_func_t next_write;
+*/
+
+/* termios ops */
+/*
+typedef int (*tcgetattr_func_t)(int, struct termios *);
+tcgetattr_func_t next_tcgetattr;
+typedef int (*tcsetattr_func_t)(int, int, const struct termios *);
+tcsetattr_func_t next_tcsetattr;
+typedef int (*tcflush_func_t)(int, int);
+tcflush_func_t next_tcflush;
+typedef int (*tcdrain_func_t)(int);
+tcdrain_func_t next_tcdrain;
+typedef int (*tcsendbreak_func_t)(int, int);
+tcsendbreak_func_t next_tcsendbreak;
+typedef int (*cfsetospeed)(struct termios *, speed_t);
+cfsetospeed_func_t next_cfsetospeed;
+typedef int (*cfsetispeed)(struct termios *, speed_t);
+cfsetispeed_func_t next_cfsetispeed;
+*/
+
+static char *pathname;
+static struct ds2480b_device ds2480b;
+static struct ds1963s_device ds1963s;
+static struct transport *serial;
+struct one_wire_bus bus;
+pthread_t one_wire_thread;
+
+void *one_wire_loop() {
+    one_wire_bus_run(&bus);
+    return NULL;
+}
+
+int ds1963s_open(const char *path, int flags) {
+    /* intercept the open() call for the serial device file and open our
+     * emulated one instead */
+    if (strcmp(path, DEFAULT_SERIAL_DEVICE) == 0) {
+        DBG_printf("%s: intercepting open() to %s\n", __FUNCTION__, path);
+        return next_open(pathname, flags);
+    }
+    return next_open(path, flags);
+}
+
+static HookEntry entries[] = {
+    HOOK_ENTRY(HOOK_TYPE_INLINE, HOOK_TARGET_BASE_EXECUTABLE, "libc.so.6", "open", ds1963s_open, &next_open, 1),
+    {}    
+};
+
+const PHookEntry plugin_init(const char* config_path){
+    one_wire_bus_init(&bus);
+    ds1963s_dev_init(&ds1963s);
+    ds2480b_dev_init(&ds2480b);
+
+    if ((serial = transport_factory_new_by_name("pty")) == NULL) {
+        fprintf(stderr, "ds1963s_in_ds2480b: failed to create serial transport\n");
+        return NULL;
+    }
+
+    {
+        struct transport_pty_data *pdata;
+        pdata = (struct transport_pty_data *)serial->private_data;
+        pathname = pdata->pathname_slave;
+        DBG_printf("[%s] Fake ds1963s ready at %s\n", __FILE__, pathname);
+    }
+
+    ds2480b_dev_connect_serial(&ds2480b, serial);
+    if (ds2480b_dev_bus_connect(&ds2480b, &bus) == -1) {
+        fprintf(stderr, "Could not connect DS2480 to 1-wire bus.\n");
+        return NULL;
+    }
+    ds1963s_dev_connect_bus(&ds1963s, &bus);
+
+    if (pthread_create(&one_wire_thread, NULL, one_wire_loop, NULL) != 0) {
+        fprintf(stderr, "Failed to create one-wire thread.\n");
+        return NULL;
+    }
+
+    return entries;
+}


### PR DESCRIPTION
* initial commit of DS1963S iButton support: emulates a DS1963S iButton in DS2480B serial housing (used in Pump It Up Pro and Pro2)
    * This uses [ds1963s-utils](https://github.com/rhuizer/ds1963s-utils) as the backend (which emulates the ds2480 device in a PTY) in a separate thread. It intercepts `open()` calls and diverts it to the PTY file created by the emulator.
* initial commit of `run_loader.sh` script
* Various Makefile fixups
    * fix microdog plugin name
    * add `-fPIC` cflag to microdog plugin build
*  get_function_address: add more error verbosity
    * log when no hooks are registered for a given plugin
    * log when `dlopen()` fails