### PR TITLE
Initial commit of reboot_blocker plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,9 @@ network.plugin:
 pit.plugin:
 	cc -shared -m32 -fPIC src/plugins/pit/pit.c $(PLUGIN_INCLUDES) -o $(PLUGIN_BUILD_ROOT)/$@
 
+reboot_blocker.plugin:
+	cc -shared -m32 -fPIC src/plugins/reboot_blocker/reboot_blocker.c $(PLUGIN_INCLUDES) -o $(PLUGIN_BUILD_ROOT)/$@
+
 s3d_opengl.plugin:
 	cc -shared -m32 -fPIC src/plugins/s3d_opengl/s3d_opengl.c $(PLUGIN_INCLUDES) -o $(PLUGIN_BUILD_ROOT)/$@
 

--- a/src/plugins/reboot_blocker/reboot_blocker.c
+++ b/src/plugins/reboot_blocker/reboot_blocker.c
@@ -1,0 +1,21 @@
+#include <linux/reboot.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include "PIUTools_SDK.h"
+#include "PIUTools_Debug.h"
+
+/* reboot_blocker: thwarts a reboot attempt and just exits the program instead */
+
+int reboot_blocker_reboot(int cmd) {
+    DBG_printf("Blocking reboot() attempt\n");
+    exit(0);
+}
+
+static HookEntry entries[] = {
+    HOOK_ENTRY(HOOK_TYPE_INLINE, HOOK_TARGET_BASE_EXECUTABLE, "libc.so.6", "reboot", reboot_blocker_reboot, NULL, 1),
+    {}
+};
+
+const PHookEntry plugin_init() {
+    return entries;
+}


### PR DESCRIPTION
reboot_blocker thwarts any attempt to reboot the system via the reboot() libc function.