### PR TITLE
ds1963s_in_ds2480b: support for static data in auth data pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ GENERIC_PLUGINS := asound ata_hdd ata_hdd_infinity eeprom exec_blocker fake_libu
 		   io_buttonboard io_mk5io io_mk6io locale lockchip \
 		   network pit s3d_opengl sighandler statfix system_info \
 		   ticket_dispenser
-PLUGINS := microdog stlfix usb_profile x11_keyboard_input $(GENERIC_PLUGINS)
+PLUGINS := ds1963s_in_ds2480b microdog stlfix usb_profile x11_keyboard_input $(GENERIC_PLUGINS)
 PLUGIN_OBJS := $(patsubst %,$(PLUGIN_BUILD_ROOT)/%.plugin,$(PLUGINS))
 
 .PHONY: plugins
@@ -67,6 +67,22 @@ $(PLUGIN_BUILD_ROOT)/usb_profile.plugin: $(wildcard src/plugins/usb_profile/*.c)
 $(PLUGIN_BUILD_ROOT)/x11_keyboard_input.plugin: $(wildcard src/plugins/x11_keyboard_input/*.c) | $(PLUGIN_BUILD_ROOT)
 	cc -shared -m32 -fPIC src/plugins/x11_keyboard_input/*.c $(PLUGIN_INCLUDES) -lX11 -o $@
 
+DS1963S_UTILS_SOURCES := src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/1-wire-bus.c \
+						 src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/coroutine.c \
+						 src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ds1963s-common.c \
+						 src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ds1963s-device.c \
+						 src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ds2480b-device.c \
+						 src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/sha1.c \
+						 src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/transport-factory.c \
+						 src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/transport-pty.c \
+						 src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/transport-unix.c \
+						 src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/transport.c
+
+DS1963S_IN_DS2480B_SOURCES := src/plugins/ds1963s_in_ds2480b/ds1963s_in_ds2480b.c \
+							  src/plugins/ds1963s_in_ds2480b/base64.c
+
+$(PLUGIN_BUILD_ROOT)/ds1963s_in_ds2480b.plugin: $(DS1963S_UTILS_SOURCES) $(DS1963S_IN_DS2480B_SOURCES)
+	cc -shared -m32 -fPIC $(CFLAGS) $(DS1963s_IN_DS2480B_SOURCES) $(DS1963S_UTILS_SOURCES) $(PLUGIN_INCLUDES) -lpthread -I src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src -o $@
 
 .PHONY: clean
 clean:

--- a/src/plugins/ds1963s_in_ds2480b/base64.c
+++ b/src/plugins/ds1963s_in_ds2480b/base64.c
@@ -1,0 +1,165 @@
+/* This is a public domain base64 implementation written by WEI Zhicheng. */
+
+#include "base64.h"
+
+#define BASE64_PAD '='
+#define BASE64DE_FIRST '+'
+#define BASE64DE_LAST 'z'
+
+/* BASE 64 encode table */
+static const char base64en[] = {
+	'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H',
+	'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P',
+	'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X',
+	'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f',
+	'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n',
+	'o', 'p', 'q', 'r', 's', 't', 'u', 'v',
+	'w', 'x', 'y', 'z', '0', '1', '2', '3',
+	'4', '5', '6', '7', '8', '9', '+', '/',
+};
+
+/* ASCII order for BASE 64 decode, 255 in unused character */
+static const unsigned char base64de[] = {
+	/* nul, soh, stx, etx, eot, enq, ack, bel, */
+	   255, 255, 255, 255, 255, 255, 255, 255,
+
+	/*  bs,  ht,  nl,  vt,  np,  cr,  so,  si, */
+	   255, 255, 255, 255, 255, 255, 255, 255,
+
+	/* dle, dc1, dc2, dc3, dc4, nak, syn, etb, */
+	   255, 255, 255, 255, 255, 255, 255, 255,
+
+	/* can,  em, sub, esc,  fs,  gs,  rs,  us, */
+	   255, 255, 255, 255, 255, 255, 255, 255,
+
+	/*  sp, '!', '"', '#', '$', '%', '&', ''', */
+	   255, 255, 255, 255, 255, 255, 255, 255,
+
+	/* '(', ')', '*', '+', ',', '-', '.', '/', */
+	   255, 255, 255,  62, 255, 255, 255,  63,
+
+	/* '0', '1', '2', '3', '4', '5', '6', '7', */
+	    52,  53,  54,  55,  56,  57,  58,  59,
+
+	/* '8', '9', ':', ';', '<', '=', '>', '?', */
+	    60,  61, 255, 255, 255, 255, 255, 255,
+
+	/* '@', 'A', 'B', 'C', 'D', 'E', 'F', 'G', */
+	   255,   0,   1,  2,   3,   4,   5,    6,
+
+	/* 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', */
+	     7,   8,   9,  10,  11,  12,  13,  14,
+
+	/* 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', */
+	    15,  16,  17,  18,  19,  20,  21,  22,
+
+	/* 'X', 'Y', 'Z', '[', '\', ']', '^', '_', */
+	    23,  24,  25, 255, 255, 255, 255, 255,
+
+	/* '`', 'a', 'b', 'c', 'd', 'e', 'f', 'g', */
+	   255,  26,  27,  28,  29,  30,  31,  32,
+
+	/* 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', */
+	    33,  34,  35,  36,  37,  38,  39,  40,
+
+	/* 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', */
+	    41,  42,  43,  44,  45,  46,  47,  48,
+
+	/* 'x', 'y', 'z', '{', '|', '}', '~', del, */
+	    49,  50,  51, 255, 255, 255, 255, 255
+};
+
+unsigned int
+base64_encode(const unsigned char *in, unsigned int inlen, char *out)
+{
+	int s;
+	unsigned int i;
+	unsigned int j;
+	unsigned char c;
+	unsigned char l;
+
+	s = 0;
+	l = 0;
+	for (i = j = 0; i < inlen; i++) {
+		c = in[i];
+
+		switch (s) {
+		case 0:
+			s = 1;
+			out[j++] = base64en[(c >> 2) & 0x3F];
+			break;
+		case 1:
+			s = 2;
+			out[j++] = base64en[((l & 0x3) << 4) | ((c >> 4) & 0xF)];
+			break;
+		case 2:
+			s = 0;
+			out[j++] = base64en[((l & 0xF) << 2) | ((c >> 6) & 0x3)];
+			out[j++] = base64en[c & 0x3F];
+			break;
+		}
+		l = c;
+	}
+
+	switch (s) {
+	case 1:
+		out[j++] = base64en[(l & 0x3) << 4];
+		out[j++] = BASE64_PAD;
+		out[j++] = BASE64_PAD;
+		break;
+	case 2:
+		out[j++] = base64en[(l & 0xF) << 2];
+		out[j++] = BASE64_PAD;
+		break;
+	}
+
+	out[j] = 0;
+
+	return j;
+}
+
+unsigned int
+base64_decode(const char *in, unsigned int inlen, unsigned char *out)
+{
+	unsigned int i;
+	unsigned int j;
+	unsigned char c;
+
+	if (inlen & 0x3) {
+		return 0;
+	}
+
+	for (i = j = 0; i < inlen; i++) {
+		if (in[i] == BASE64_PAD) {
+			break;
+		}
+		if (in[i] < BASE64DE_FIRST || in[i] > BASE64DE_LAST) {
+			return 0;
+		}
+
+		c = base64de[(unsigned char)in[i]];
+		if (c == 255) {
+			return 0;
+		}
+
+		switch (i & 0x3) {
+		case 0:
+			out[j] = (c << 2) & 0xFF;
+			break;
+		case 1:
+			out[j++] |= (c >> 4) & 0x3;
+			out[j] = (c & 0xF) << 4; 
+			break;
+		case 2:
+			out[j++] |= (c >> 2) & 0xF;
+			out[j] = (c & 0x3) << 6;
+			break;
+		case 3:
+			out[j++] |= c;
+			break;
+		}
+	}
+
+	return j;
+}
+

--- a/src/plugins/ds1963s_in_ds2480b/base64.h
+++ b/src/plugins/ds1963s_in_ds2480b/base64.h
@@ -1,0 +1,21 @@
+#ifndef BASE64_H
+#define BASE64_H
+
+#define BASE64_ENCODE_OUT_SIZE(s) ((unsigned int)((((s) + 2) / 3) * 4 + 1))
+#define BASE64_DECODE_OUT_SIZE(s) ((unsigned int)(((s) / 4) * 3))
+
+/*
+ * out is null-terminated encode string.
+ * return values is out length, exclusive terminating `\0'
+ */
+unsigned int
+base64_encode(const unsigned char *in, unsigned int inlen, char *out);
+
+/*
+ * return values is out length
+ */
+unsigned int
+base64_decode(const char *in, unsigned int inlen, unsigned char *out);
+
+#endif /* BASE64_H */
+

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/.gitignore
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/.gitignore
@@ -1,0 +1,8 @@
+CMakeCache.txt
+CMakeFiles/
+Makefile
+cmake_install.cmake
+ds1963s-brute
+ds1963s-tool
+tags
+ibutton/libibutton.a

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/1-wire-bus.c
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/1-wire-bus.c
@@ -1,0 +1,277 @@
+/* 1-wire-bus.c
+ *
+ * A virtual 1-wire bus implementation.
+ *
+ * Dedicated to Yuzuyu Arielle Huizer.
+ *
+ * Copyright (C) 2016-2019  Ronald Huizer <rhuizer@hexpedition.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include "1-wire-bus.h"
+
+#ifndef DEBUG_BUS
+#undef DEBUG_LOG
+#define DEBUG_LOG(x, ...)
+#endif
+
+static inline int
+__one_wire_bus_cycle(struct one_wire_bus *bus)
+{
+	struct list_head *lh, *lh2;
+	int signal;
+
+	assert(bus != NULL);
+
+	DEBUG_LOG("[1-wire-bus] cycle #%"PRIu64"\n", bus->cycle++);
+
+	/* If we have no members, there is nothing to drive anything so we
+	 * just terminate.
+	 */
+	if (list_empty(&bus->members))
+		return -1;
+
+	/* Default to a 1 signalled by positive voltage. */
+	signal = ONE_WIRE_BUS_SIGNAL_ONE;
+
+	/* In a single bus cycle, we first iterate over all members that are
+	 * not yet accessing the bus.  To keep every member in lock-step it
+	 * is necessary to wait until every member is accessing the bus for
+	 * either read or write operations.
+	 */
+	list_for_each_safe (lh, lh2, &bus->members) {
+		int tmp;
+		struct one_wire_bus_member *m =
+			list_entry(lh, struct one_wire_bus_member, list_entry);
+
+		/* If we are terminating, we send all members the signal. */
+		if (bus->state == ONE_WIRE_BUS_STATE_TERMINATED) {
+			bus->signal = ONE_WIRE_BUS_SIGNAL_TERMINATE;
+			coroutine_yieldto(&bus->coro, &m->coro);
+			continue;
+		}
+
+		if (m->bus_access != ONE_WIRE_BUS_ACCESS_NONE)
+			continue;
+
+		/* The 1-wire signal is a logical and over all devices on the
+		 * line.  If one pulls the line low, it will be low.
+		 */
+		tmp = (int)(intptr_t)coroutine_await(&bus->coro, &m->coro);
+
+		/* It's possible the bus member disappeared during our await,
+		 * so we check if it is still present.  If not we skip
+		 * updating the signal.
+		 *
+		 * XXX: maybe try to solve this in coroutine.c
+		 */
+		if (list_empty(&m->list_entry))
+			continue;
+
+		if (tmp == -1)
+			signal = -1;
+		else if (signal != -1)
+			signal &= tmp;
+
+		DEBUG_LOG("[1-wire-bus] %s signal %d\n", m->name, signal);
+	}
+
+	bus->signal = signal;
+	DEBUG_LOG("[1-wire-bus] final bus signal %d\n", bus->signal);
+
+	return 0;
+}
+
+static void
+__one_wire_bus_coroutine(struct coroutine *coro)
+{
+	struct one_wire_bus *bus;
+
+	assert(coro != NULL);
+	assert(coro->cookie != NULL);
+
+	bus = (struct one_wire_bus *)coro->cookie;
+
+	/* The bus keeps all attached members in lock-step by simply
+	 * yielding to all of them once to simulate a bus cycle.
+	 */
+	while (__one_wire_bus_cycle(bus) == 0);
+}
+
+static void
+__one_wire_bus_member_coroutine(struct coroutine *coro)
+{
+	struct one_wire_bus_member *member;
+
+	assert(coro != NULL);
+	assert(coro->cookie != NULL);
+
+	member = (struct one_wire_bus_member *)coro->cookie;
+	member->driver(member->device);
+}
+
+static void
+__one_wire_bus_member_destructor(struct coroutine *coro)
+{
+	struct one_wire_bus_member *member;
+
+	assert(coro != NULL);
+	assert(coro->cookie != NULL);
+	member = (struct one_wire_bus_member *)coro->cookie;
+
+	/* If the master goes, shut down the whole bus. */
+	if (member->type == ONE_WIRE_BUS_MEMBER_MASTER)
+		member->bus->state = ONE_WIRE_BUS_STATE_TERMINATED;
+
+	one_wire_bus_member_remove(member);
+}
+
+void one_wire_bus_init(struct one_wire_bus *bus)
+{
+	assert(bus != NULL);
+
+	memset(bus, 0, sizeof *bus);
+	bus->state  = ONE_WIRE_BUS_STATE_TERMINATED;
+	bus->signal = ONE_WIRE_BUS_SIGNAL_ONE;
+	list_init(&bus->members);
+	coroutine_init(&bus->coro, __one_wire_bus_coroutine, bus);
+}
+
+void one_wire_bus_member_init(struct one_wire_bus_member *member)
+{
+	assert(member != NULL);
+
+	memset(member, 0, sizeof *member);
+	member->type       = ONE_WIRE_BUS_MEMBER_SLAVE;
+	member->bus_access = ONE_WIRE_BUS_ACCESS_NONE;
+	list_init(&member->list_entry);
+}
+
+int
+one_wire_bus_member_add(struct one_wire_bus_member *member,
+                        struct one_wire_bus *bus)
+{
+	assert(bus != NULL);
+	assert(member != NULL);
+	assert(list_empty(&member->list_entry));
+
+	DEBUG_LOG("[1-wire-bus] Adding member `%s'\n", member->name);
+
+	member->bus = bus;
+	list_add(&member->list_entry, &bus->members);
+	coroutine_init(&member->coro, __one_wire_bus_member_coroutine, member);
+	coroutine_destructor_set(&member->coro, __one_wire_bus_member_destructor);
+
+	return 0;
+}
+
+void
+one_wire_bus_member_master_set(struct one_wire_bus_member *member)
+{
+	assert(member != NULL);
+	member->type = ONE_WIRE_BUS_MEMBER_MASTER;
+}
+
+void
+one_wire_bus_member_remove(struct one_wire_bus_member *member)
+{
+	assert(member != NULL);
+	assert(member->bus != NULL);
+	assert(!list_empty(&member->list_entry));
+
+	DEBUG_LOG("[1-wire-bus] Removing member `%s'\n", member->name);
+
+	member->bus = NULL;
+	list_del_init(&member->list_entry);
+}
+
+int
+one_wire_bus_member_tx_bit(struct one_wire_bus_member *member, int bit)
+{
+	assert(member != NULL);
+	assert(member->bus != NULL);
+	assert(bit == 0 || bit == 1);
+
+	coroutine_returnto(&member->coro, &member->bus->coro, (void *)(intptr_t)bit);
+	DEBUG_LOG("[1-wire-bus] %s tx %d rx %d\n", member->name, bit, member->bus->signal);
+	return member->bus->signal;
+}
+
+int
+one_wire_bus_member_rx_bit(struct one_wire_bus_member *member)
+{
+	assert(member != NULL);
+	assert(member->bus != NULL);
+
+	coroutine_returnto(&member->coro, &member->bus->coro, (void *)1);
+
+	DEBUG_LOG("[1-wire-bus] %s rx %d\n", member->name, member->bus->signal);
+
+	return member->bus->signal;
+}
+
+void
+one_wire_bus_member_reset_pulse(struct one_wire_bus_member *member)
+{
+	assert(member != NULL);
+	assert(member->bus != NULL);
+
+	coroutine_returnto(&member->coro, &member->bus->coro, (void *)-1);
+	DEBUG_LOG("[1-wire-bus] %s tx reset pulse\n", member->name);
+}
+
+int one_wire_bus_member_rx_byte(struct one_wire_bus_member *member)
+{
+	int result = 0;
+	int bit;
+	int i;
+
+	for (i = 0; i < 8; i++) {
+		bit = one_wire_bus_member_rx_bit(member);
+
+		if (bit == ONE_WIRE_BUS_SIGNAL_RESET)
+			return ONE_WIRE_BUS_SIGNAL_RESET;
+
+		result |= bit << i;
+	}
+
+	return result;
+}
+
+int
+one_wire_bus_member_tx_byte(struct one_wire_bus_member *member, int byte)
+{
+	int result = 0;
+	int bit;
+
+	for (int i = 0; i < 8; i++) {
+		bit = one_wire_bus_member_tx_bit(member, (byte >> i) & 1);
+
+		if (bit == ONE_WIRE_BUS_SIGNAL_RESET)
+			return ONE_WIRE_BUS_SIGNAL_RESET;
+
+		result |= bit << i;
+	}
+
+	return result;
+}
+
+int one_wire_bus_run(struct one_wire_bus *bus)
+{
+	bus->state = ONE_WIRE_BUS_STATE_RUNNING;
+	return coroutine_main();
+}

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/1-wire-bus.h
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/1-wire-bus.h
@@ -1,0 +1,103 @@
+/* 1-wire-bus.h
+ *
+ * A virtual 1-wire bus implementation.
+ *
+ * Dedicated to Yuzuyu Arielle Huizer.
+ *
+ * Copyright (C) 2016-2019  Ronald Huizer <rhuizer@hexpedition.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef ONE_WIRE_BUS_H
+#define ONE_WIRE_BUS_H
+
+#include <inttypes.h>
+#include "coroutine.h"
+#include "debug.h"
+#include "list.h"
+
+/* Do not redefine these three, it will break things. */
+#define ONE_WIRE_BUS_SIGNAL_TERMINATE	-2
+#define ONE_WIRE_BUS_SIGNAL_RESET	-1
+#define ONE_WIRE_BUS_SIGNAL_ZERO	0
+#define ONE_WIRE_BUS_SIGNAL_ONE		1
+
+#define ONE_WIRE_BUS_ACCESS_NONE	0
+#define ONE_WIRE_BUS_ACCESS_READ	1
+#define ONE_WIRE_BUS_ACCESS_WRITE	2
+
+#define ONE_WIRE_BUS_STATE_RUNNING	0
+#define ONE_WIRE_BUS_STATE_TERMINATED	1
+
+#define ONE_WIRE_BUS_MEMBER_MASTER	0
+#define ONE_WIRE_BUS_MEMBER_SLAVE	1
+
+struct one_wire_bus;
+
+typedef void (*bus_device_driver_t)(void *);
+
+struct one_wire_bus_member
+{
+	int                  type;
+	struct coroutine     coro;
+	struct one_wire_bus *bus;
+	struct list_head     list_entry;
+	int	             bus_access;
+	void *               device;
+	bus_device_driver_t  driver;
+#ifdef DEBUG
+	char                 name[16];
+#endif
+};
+
+struct one_wire_bus
+{
+	int              state;
+	struct list_head members;
+	struct coroutine coro;
+	int              signal;
+#ifdef DEBUG
+	uint64_t         cycle;
+#endif
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void one_wire_bus_init(struct one_wire_bus *bus);
+int  one_wire_bus_run(struct one_wire_bus *bus);
+
+void one_wire_bus_member_init(struct one_wire_bus_member *member);
+int  one_wire_bus_member_add(struct one_wire_bus_member *, struct one_wire_bus *);
+void one_wire_bus_member_remove(struct one_wire_bus_member *);
+
+void one_wire_bus_member_master_set(struct one_wire_bus_member *member);
+
+void one_wire_bus_member_reset_pulse(struct one_wire_bus_member *);
+int  one_wire_bus_member_tx_bit(struct one_wire_bus_member *, int);
+int  one_wire_bus_member_rx_bit(struct one_wire_bus_member *);
+int  one_wire_bus_member_rx_byte(struct one_wire_bus_member *);
+int  one_wire_bus_member_tx_byte(struct one_wire_bus_member *, int);
+
+void one_wire_bus_member_write_bit(struct one_wire_bus_member *member, int bit);
+void one_wire_bus_member_write_byte(struct one_wire_bus_member *member, int byte);
+int  one_wire_bus_member_read_bit(struct one_wire_bus_member *member, int bit);
+int  one_wire_bus_member_read_byte(struct one_wire_bus_member *member, int byte);
+
+#ifdef __cplusplus
+};
+#endif
+
+#endif

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/CMakeLists.txt
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/CMakeLists.txt
@@ -1,0 +1,29 @@
+FIND_LIBRARY(LIBYAML NAMES yaml libyaml)
+if (LIBYAML)
+    add_definitions(-DHAVE_LIBYAML)
+endif()
+
+add_subdirectory(ibutton)
+
+set(SOURCES ds1963s-common.c ds1963s-client.c ds1963s-device.c ds1963s-error.c
+            ds2480b-device.c transport.c transport-factory.c transport-unix.c
+            transport-pty.c coroutine.c 1-wire-bus.c)
+add_library(ds1963s ${SOURCES})
+target_link_libraries(ds1963s ibutton)
+
+if (LIBYAML)
+add_executable(ds1963s-tool ds1963s-tool.c ds1963s-tool-yaml.c)
+target_link_libraries(ds1963s-tool ds1963s crypto yaml)
+
+add_executable(ds1963s-emulator ds1963s-emulator.c ds1963s-emulator-yaml.c)
+target_link_libraries(ds1963s-emulator ds1963s crypto yaml)
+else()
+add_executable(ds1963s-tool ds1963s-tool.c ds1963s-tool-yaml.c)
+target_link_libraries(ds1963s-tool ds1963s crypto)
+
+add_executable(ds1963s-emulator ds1963s-emulator.c)
+target_link_libraries(ds1963s-emulator ds1963s crypto)
+endif()
+
+add_executable(ds1963s-shell ds1963s-shell.c)
+target_link_libraries(ds1963s-shell ds1963s readline)

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/coroutine.c
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/coroutine.c
@@ -1,0 +1,277 @@
+/* coroutine.c
+ *
+ * A small and simple coroutine library written in C.
+ *
+ * Dedicated to Yuzuyu Arielle Huizer.
+ *
+ * Copyright (C) 2016-2019  Ronald Huizer <rhuizer@hexpedition.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#include <assert.h>
+#include <stdlib.h>
+#include <ucontext.h>
+#include "coroutine.h"
+#include "debug.h"
+#include "list.h"
+
+#ifdef DEBUG_COROUTINE
+#include <valgrind/valgrind.h>
+#endif
+
+static size_t stack_size = 65536;
+static ucontext_t main_context;
+static ucontext_t cleanup_context;
+static struct coroutine *coro_current;
+static struct list_head active_list = LIST_HEAD_INIT(active_list);
+
+int coroutine_init(struct coroutine *coro, coroutine_handler_t f, void *cookie)
+{
+	unsigned char *stack;
+
+	if (getcontext(&coro->context) == -1)
+		return -1;
+
+	if ( (stack = malloc(stack_size)) == NULL)
+		return -1;
+
+	coro->destructor                = NULL;
+	coro->cookie                    = cookie;
+	coro->data			= NULL;
+	coro->context.uc_link           = &cleanup_context;
+	coro->context.uc_stack.ss_sp    = stack;
+	coro->context.uc_stack.ss_size  = stack_size;
+	coro->context.uc_stack.ss_flags = 0;
+	list_add_tail(&coro->entry, &active_list);
+	list_init(&coro->yield_list);
+
+#ifdef DEBUG_COROUTINE
+	coro->stack_id = VALGRIND_STACK_REGISTER(stack, stack + stack_size);
+#endif
+
+	makecontext(&coro->context, (void (*)())f, 1, coro);
+
+	return 0;
+}
+
+void
+coroutine_destructor_set(struct coroutine *coro, coroutine_destructor_t d)
+{
+	coro->destructor = d;
+}
+
+void coroutine_reschedule(struct coroutine *coro)
+{
+	coro_current = coro;
+	list_del(&coro->entry);
+	list_add_tail(&coro->entry, &active_list);
+}
+
+void *coroutine_await(struct coroutine *coro, struct coroutine *other)
+{
+	/* coroutine_await should not be called on an inactive coroutine. */
+	/* XXX: test this. */
+
+	/* Remove the coroutine waiting from the active_list. */
+	list_del(&coro->entry);
+
+	/* Insert the coroutine waiting into the yield list of the
+	 * coroutine it waits on.
+	 */
+	list_add_tail(&coro->entry, &other->yield_list);
+
+	coroutine_reschedule(other);
+	if (swapcontext(&coro->context, &other->context) == -1)
+		return NULL;
+
+	/* Take it from the yield list and reschedule. */
+	coroutine_reschedule(coro);
+
+	return other->data;
+}
+
+/* Yield to an arbitrary other coroutine. */
+int coroutine_yield(struct coroutine *coro)
+{
+	struct coroutine *other;
+
+	/* Nothing to reschedule to, so we're done. */
+	if (list_empty(&active_list))
+		return 0;
+
+	other = list_entry(active_list.next, struct coroutine, entry);
+	return coroutine_yieldto(coro, other);
+}
+
+/* Yield to a specific other coroutine. */
+int coroutine_yieldto(struct coroutine *coro, struct coroutine *other)
+{
+	assert(coro != NULL);
+	assert(other != NULL);
+
+	coroutine_reschedule(other);
+	if (swapcontext(&coro->context, &other->context) == -1)
+		return -1;
+
+	return 0;
+}
+
+/* Return data to a coroutine waiting for this one. */
+int coroutine_return(struct coroutine *coro, void *data)
+{
+	struct coroutine *other;
+
+	/* If there is no coroutine waiting on this yield, schedule the next
+	 * routine from the active_list.
+	 */
+	if (list_empty(&coro->yield_list))
+		return coroutine_yield(coro);
+
+	other = list_entry(coro->yield_list.next, struct coroutine, entry);
+
+	/* Remove the selected coroutine from the yield list. */
+	list_del(&other->entry);
+	list_add_tail(&other->entry, &active_list);
+
+	return coroutine_returnto(coro, other, data);
+}
+
+int coroutine_returnto(struct coroutine *coro, struct coroutine *other, void *data)
+{
+	/* XXX: Would like to test if 'other' on yield_list of 'coro' ... */
+	coro->data = data;
+
+	coroutine_reschedule(other);
+	if (swapcontext(&coro->context, &other->context) == -1)
+		return -1;
+
+	return 0;
+}
+
+void coroutine_destroy(struct coroutine *coro)
+{
+#ifdef DEBUG_COROUTINE
+	VALGRIND_STACK_DEREGISTER(coro->stack_id);
+#endif
+	list_del(&coro->entry);
+	free(coro->context.uc_stack.ss_sp);
+}
+
+void coroutine_end(void)
+{
+	if (coro_current->destructor != NULL)
+		coro_current->destructor(coro_current);
+
+	coroutine_destroy(coro_current);
+}
+
+int coroutine_main(void)
+{
+	static unsigned char stack[65536];
+	struct coroutine *coro;
+	int id;
+
+	/* This is the place where we store and will return to the main
+	 * context once the active_list is empty.  We cannoy modify the
+	 * context after we set it in the uc_link of another context which
+	 * we then makecontext(), so this has to be done here.
+	 */
+	getcontext(&main_context);
+	if (list_empty(&active_list))
+		return 0;
+
+	getcontext(&cleanup_context);
+	cleanup_context.uc_link           = &main_context;
+	cleanup_context.uc_stack.ss_sp    = stack;
+	cleanup_context.uc_stack.ss_size  = sizeof(stack);
+	cleanup_context.uc_stack.ss_flags = 0;
+#ifdef DEBUG_COROUTINE
+	id = VALGRIND_STACK_REGISTER(stack, stack + sizeof stack);
+#endif
+	makecontext(&cleanup_context, coroutine_end, 0);
+
+	/* Main loop; this is only relevant when coroutine_end is called,
+	 * as that is the only way we will reenter the cleanup_context above.
+	 */
+	if (!list_empty(&active_list)) {
+		coro = list_entry(active_list.next, struct coroutine, entry);
+		coroutine_reschedule(coro);
+		setcontext(&coro->context);
+	}
+
+#ifdef DEBUG_COROUTINE
+	VALGRIND_STACK_DEREGISTER(id);
+#endif
+	return 0;
+}
+
+#ifdef TEST
+struct coroutine coro_f;
+struct coroutine coro_g;
+struct coroutine coro_h;
+
+void f(struct coroutine *coro)
+{
+	int i;
+
+	printf("cookie: %p\n", coro->cookie);
+
+	for (i = 0; i < 50; i++) {
+		printf("coroutine f\n");
+		coroutine_return(coro, (void *)i);
+		printf("after yield\n");
+	}
+}
+
+void g(struct coroutine *coro)
+{
+	void *ret;
+	int i;
+
+	printf("coroutine g\n");
+	printf("g: main: %p\n", &main_context);
+	printf("g: main.uc_link: %p\n", main_context.uc_link);
+	printf("g: cleanup: %p\n", &cleanup_context);
+	printf("g: link: %p\n", coro->context.uc_link);
+
+	coroutine_return(coro, NULL);
+}
+
+void h(struct coroutine *coro)
+{
+	void *ret;
+	int i;
+
+	for (i = 0; i < 50; i++) {
+		printf("coroutine h\n");
+		ret = coroutine_await(coro, &coro_f);
+		printf("coroutine h got: %d\n", ret);
+	}
+}
+
+int main(void)
+{
+	coroutine_init(&coro_f, f, 0x41414141);
+	coroutine_init(&coro_g, g, NULL);
+	coroutine_init(&coro_h, h, NULL);
+
+	coroutine_main();
+	printf("back in main()\n");
+}
+#endif

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/coroutine.h
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/coroutine.h
@@ -1,0 +1,71 @@
+/* coroutine.h
+ *
+ * A small and simple coroutine library written in C.
+ *
+ * Dedicated to Yuzuyu Arielle Huizer.
+ *
+ * Copyright (C) 2016-2019  Ronald Huizer <rhuizer@hexpedition.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef COROUTINE_H
+#define COROUTINE_H
+
+#include <ucontext.h>
+#include "debug.h"
+#include "list.h"
+
+struct coroutine;
+
+typedef void (*coroutine_handler_t)(struct coroutine *);
+typedef void (*coroutine_destructor_t)(struct coroutine *);
+
+struct coroutine
+{
+	coroutine_destructor_t	destructor;
+	void			*cookie;
+	void			*data;
+	struct list_head	entry;
+	struct list_head	yield_list;
+	ucontext_t		context;
+#ifdef DEBUG
+	int			stack_id;
+#endif
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int   coroutine_init(struct coroutine *, coroutine_handler_t, void *);
+void  coroutine_destructor_set(struct coroutine *, coroutine_destructor_t);
+void *coroutine_await(struct coroutine *, struct coroutine *);
+int   coroutine_return(struct coroutine *, void *);
+int   coroutine_returnto(struct coroutine *, struct coroutine *, void *);
+int   coroutine_yieldto(struct coroutine *, struct coroutine *);
+int   coroutine_yield(struct coroutine *);
+void  coroutine_destroy(struct coroutine *);
+
+int   coroutine_main(void);
+
+#ifdef __cplusplus
+};
+#endif
+
+#endif

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/debug.h
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/debug.h
@@ -1,0 +1,16 @@
+#ifndef DEBUG_H
+#define DEBUG_H
+
+#include <assert.h>
+
+#ifndef NDEBUG
+#define DEBUG
+#define DEBUG_LOG(fmt, ...)						\
+	do {								\
+		fprintf(stderr, fmt, ## __VA_ARGS__);			\
+	} while (0)
+#else
+#define DEBUG_LOG(fmt, ...)
+#endif
+
+#endif

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ds1963s-client.c
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ds1963s-client.c
@@ -1,0 +1,755 @@
+/* ds1963s-client.c
+ *
+ * A ds1963s emulation and utility framework.
+ *
+ * Dedicated to Yuzuyu Arielle Huizer.
+ *
+ * Copyright (C) 2013-2019  Ronald Huizer <rhuizer@hexpedition.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include <assert.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include "getput.h"
+#include "ibutton/ds2480.h"
+#include "ibutton/ownet.h"
+#include "ibutton/shaib.h"
+#include "ds1963s-common.h"
+#include "ds1963s-client.h"
+#include "ds1963s-error.h"
+
+#define MIN(x, y) ((x) < (y) ? (x) : (y))
+
+extern int fd[MAX_PORTNUM];
+void owClearError(void);
+
+static int __ds1963s_acquire(struct ds1963s_client *ctx, const char *port)
+{
+	int portnum;
+
+	if ( (portnum = OpenCOMEx(port)) < 0) {
+		ctx->errno = DS1963S_ERROR_OPENCOM;
+		return -1;
+	}
+
+	if (!DS2480Detect(portnum)) {
+		CloseCOM(portnum);
+		ctx->errno = DS1963S_ERROR_NO_DS2480;
+		return -1;
+	}
+
+	return portnum;
+}
+
+static int
+__ds1963s_find(struct ds1963s_client *ctx, int portnum, unsigned char *devAN)
+{
+	/* XXX: FindNewSHA can return FALSE without adding an error to the
+	 * error stack (when it does not find any buttons).  We need to
+	 * differentiate.
+	 */
+	owClearError();
+
+	if (FindNewSHA(portnum, devAN, TRUE) == TRUE)
+		return 0;
+
+	/* XXX: this is dependent on FindNewSHA internals. */
+	if (owHasErrors()) {
+		ctx->errno = DS1963S_ERROR_SET_LEVEL;
+		return -1;
+	}
+
+	/* We did not find any new SHA based ibuttons. */
+	ctx->errno = DS1963S_ERROR_NOT_FOUND;
+	return -1;
+}
+
+int
+ds1963s_client_init(ds1963s_client_t *ctx, const char *device)
+{
+	SHACopr *copr = &ctx->copr;
+
+	/* Get port. */
+	if ( (copr->portnum = __ds1963s_acquire(ctx, device)) == -1)
+		return -1;
+
+	/* Find DS1963S iButton. */
+	if (__ds1963s_find(ctx, copr->portnum, copr->devAN) == -1)
+		return -1;
+
+	ctx->resume      = 0;
+	ctx->device_path = device;
+	ctx->errno       = 0;
+
+	return 0;
+}
+
+void
+ds1963s_client_destroy(ds1963s_client_t *ctx)
+{
+	owRelease(ctx->copr.portnum);
+}
+
+static inline int
+__ds1963s_client_select_sha(ds1963s_client_t *ctx)
+{
+	if (SelectSHA(ctx->copr.portnum) == FALSE) {
+		ctx->errno = DS1963S_ERROR_ACCESS;
+		return -1;
+        }
+
+	return 0;
+}
+
+int
+ds1963s_client_page_to_address(ds1963s_client_t *ctx, int page)
+{
+	if (page < 0 || page > 21) {
+		ctx->errno = DS1963S_ERROR_INVALID_PAGE;
+		return -1;
+	}
+
+	return page * 32;
+}
+
+int
+ds1963s_client_address_to_page(ds1963s_client_t *ctx, int address)
+{
+	if (address < 0 || address > 0x2c0) {
+		ctx->errno = DS1963S_ERROR_INVALID_ADDRESS;
+		return -1;
+	}
+
+	return address / 32;
+}
+
+void
+ds1963s_client_rom_get(ds1963s_client_t *ctx, struct ds1963s_rom *rom)
+{
+	int portnum = ctx->copr.portnum;
+
+	owSerialNum(portnum, rom->raw, TRUE);
+
+	rom->family = rom->raw[0];
+	rom->crc    = rom->raw[7];
+	rom->crc_ok = ds1963s_crc8(rom->raw, 8) == 0;
+
+	for (int i = 0; i < 6; i++)
+		rom->serial[i] = rom->raw[6 - i];
+}
+
+int ds1963s_client_taes_print(struct ds1963s_client *ctx)
+{
+	uint16_t addr;
+	uint8_t es;
+
+	if (ds1963s_client_taes_get(ctx, &addr, &es) == -1)
+		return -1;
+
+	printf("TA2: 0x%.2x TA1: 0x%.2x E/S: 0x%.2x\n",
+		addr >> 8, addr & 0xff, es);
+
+	return 0;
+}
+
+void ds1963s_client_hash_print(uint8_t hash[20])
+{
+	int i;
+
+	for (i = 0; i < 20; i++)
+		printf("%.2x", hash[i]);
+	printf("\n");
+}
+
+int
+ds1963s_client_taes_get(struct ds1963s_client *ctx, uint16_t *addr, uint8_t *es)
+{
+	uint8_t buf[DS1963S_SCRATCHPAD_SIZE];
+	int portnum = ctx->copr.portnum;
+	uint8_t __es;
+	int __addr;
+
+        OWASSERT(ReadScratchpadSHA18(portnum, &__addr, &__es, buf, 0),
+                 OWERROR_READ_SCRATCHPAD_FAILED, -1);
+
+	if (addr)
+		*addr = __addr;
+
+	if (es)
+		*es = __es;
+
+	return 0;
+}
+
+int
+ds1963s_client_hash_read(ds1963s_client_t *ctx, uint8_t h[DS1963S_HASH_SIZE])
+{
+	ds1963s_client_sp_read_reply_t reply;
+
+	if (ds1963s_client_sp_read(ctx, &reply) == -1)
+		return -1;
+
+	if (reply.crc_ok == 0)
+		return -1;
+
+	if (reply.data_size != 32) {
+		ctx->errno = DS1963S_ERROR_DATA_LEN;
+		return -1;
+	}
+
+	memcpy(h, &reply.data[8], DS1963S_HASH_SIZE);
+
+	return 0;
+}
+
+int
+ds1963s_client_sp_read(ds1963s_client_t *ctx, ds1963s_client_sp_read_reply_t *reply)
+{
+	int portnum = ctx->copr.portnum;
+	size_t bytes_read;
+	uint8_t buf[40];
+	uint16_t crc;
+	int i = 0;
+
+	if (ctx->resume)
+		buf[i++] = ROM_CMD_RESUME;
+	else if (__ds1963s_client_select_sha(ctx) == -1)
+		return -1;
+
+	buf[i++] = CMD_READ_SCRATCHPAD;
+
+	/* Padding for transmission of TA1 TA2 E/S CRC16 and data. */
+	memset(&buf[i], 0xff, 37);
+	i += 37;
+
+	/* Send the buffer out. */
+	OWASSERT(owBlock(portnum, ctx->resume, buf, i), OWERROR_BLOCK_FAILED, -1);
+
+	/* Calculate the bytes read from the scratchpad based on TA1(4:0). */
+	bytes_read = buf[ctx->resume + 1];
+	bytes_read = 32 - (bytes_read & 0x1F);
+
+	/* Calculate the CRC16. */
+	crc = ds1963s_crc16(&buf[ctx->resume], bytes_read + 6);
+
+	/* Copy the data we've read. */
+	reply->data_size = bytes_read;
+	memcpy(reply->data, &buf[ctx->resume + 4], reply->data_size);
+
+	reply->address = ds1963s_ta_to_address(buf[ctx->resume + 1],
+	                                       buf[ctx->resume + 2]);
+
+	reply->es     = buf[ctx->resume + 3];
+	reply->crc16  = ~GET_16BIT_MSB(&buf[bytes_read + 4 + ctx->resume]);
+	reply->crc_ok = crc == 0xB001;
+
+	/* This is not a hard error because the client may be interested in
+	 * the reply regardless of the checksum, but we flag the error here
+	 * in case the client handles it.
+	 */
+	if (reply->crc_ok == 0)
+		ctx->errno = DS1963S_ERROR_INTEGRITY;
+
+	/* Return the number of bytes read. */
+	return bytes_read;
+}
+
+int
+ds1963s_client_read_auth(ds1963s_client_t *ctx, int address,
+                         ds1963s_client_read_auth_page_reply_t *reply)
+{
+	int portnum = ctx->copr.portnum;
+	uint8_t read_size;
+	uint8_t buf[56];
+	uint16_t crc;
+	int num_verf;
+	int i = 0;
+
+	assert(ctx != NULL);
+	assert(reply != NULL);
+	assert(address >= 0 && address <= 0xFFFF);
+
+	if (ctx->resume)
+		buf[i++] = ROM_CMD_RESUME;
+	else if (__ds1963s_client_select_sha(ctx) == -1)
+		return -1;
+
+	read_size = 32 - (address % 32);
+
+	/* XXX: study how overdrive works. */
+	num_verf = (in_overdrive[portnum&0x0FF]) ? 10 : 2;
+
+	buf[i++] = CMD_READ_AUTH_PAGE;
+	buf[i++] = address & 0xFF;
+	buf[i++] = address >> 8;
+
+	/* Padding for transmission of WC counters, TA2, CRC16, data, and
+	 * the verification pattern.
+	 */
+	memset(&buf[i], 0xFF, 10 + read_size + num_verf);
+	i += 10 + read_size + num_verf;
+
+	/* Send the block. */
+	OWASSERT(owBlock(portnum, ctx->resume, buf, i),
+	         OWERROR_BLOCK_FAILED, -1);
+
+	/* Calculate the CRC over the received data; that is command byte,
+	 * address, data, counters, and the 16-bit crc received.
+	 */
+	crc = ds1963s_crc16(buf + ctx->resume, read_size + 13);
+
+	/* The DS1963S sends 1 bits during SHA1 computation and signals
+	 * that the SHA1 computation finished by sending an alternating pattern
+	 * of 0 and 1 bits.  We detect this pattern here.
+	 */
+	OWASSERT( ((buf[i - 1] & 0xF0) == 0x50) ||
+             ((buf[i - 1] & 0xF0) == 0xA0),
+             OWERROR_NO_COMPLETION_BYTE, -1);
+
+	memcpy(reply->data, &buf[i - 10 - read_size - num_verf], read_size);
+	reply->data_size = read_size;
+	reply->data_wc   = GET_32BIT_LSB(&buf[i - 10 - num_verf]);
+	reply->secret_wc = GET_32BIT_LSB(&buf[i - 6 - num_verf]);
+	reply->crc16     = ~GET_16BIT_MSB(&buf[10 + read_size + 1 + ctx->resume]);
+	reply->crc_ok    = crc == 0xB001;
+
+	return 0;
+}
+
+int
+ds1963s_client_sha_command(ds1963s_client_t *ctx, uint8_t cmd, int address)
+{
+	int portnum;
+
+	assert(ctx != NULL);
+	assert(address >= 0 && address <= 0xFFFF);
+
+       	portnum = ctx->copr.portnum;
+	/* Generate the secret using the SHA cmd command. */
+	if (SHAFunction18(portnum, cmd, address, ctx->resume) == FALSE) {
+		ctx->errno = DS1963S_ERROR_SHA_FUNCTION;
+		return -1;
+	}
+
+	return 0;
+}
+
+int
+ds1963s_client_secret_compute_first(ds1963s_client_t *ctx, int address)
+{
+	return ds1963s_client_sha_command(ctx, 0x0F, address);
+}
+
+int
+ds1963s_client_secret_compute_next(ds1963s_client_t *ctx, int address)
+{
+	return ds1963s_client_sha_command(ctx, 0xF0, address);
+}
+
+int
+ds1963s_client_validate_data_page(ds1963s_client_t *ctx, int address)
+{
+	return ds1963s_client_sha_command(ctx, 0x3C, address);
+}
+
+int
+ds1963s_client_sign_data_page(ds1963s_client_t *ctx, int address)
+{
+	return ds1963s_client_sha_command(ctx, 0xC3, address);
+}
+
+int
+ds1963s_client_compute_challenge(ds1963s_client_t *ctx, int address)
+{
+	return ds1963s_client_sha_command(ctx, 0xCC, address);
+}
+
+int
+ds1963s_client_authenticate_host(ds1963s_client_t *ctx, int address)
+{
+	return ds1963s_client_sha_command(ctx, 0xAA, address);
+}
+
+int
+ds1963s_client_sp_copy(struct ds1963s_client *ctx, int address, uint8_t es)
+{
+	int     portnum = ctx->copr.portnum;
+	uint8_t buf[10];
+	int     num_verf;
+	int     i = 0;
+
+	if (ctx->resume) {
+		buf[i++] = ROM_CMD_RESUME;
+	} else if (__ds1963s_client_select_sha(ctx) == -1) {
+		return -1;
+	}
+
+	// change number of verification bytes if in overdrive
+	num_verf = (in_overdrive[portnum&0xFF]) ? 4 : 2;
+
+	buf[i++] = CMD_COPY_SCRATCHPAD;
+	buf[i++] = address & 0xFF;
+	buf[i++] = (address >> 8) & 0xFF;
+	buf[i++] = es;
+
+	// verification bytes
+	memset(&buf[i], 0xFF, num_verf);
+	i += num_verf;
+
+	// now send the block
+	OWASSERT( owBlock(portnum, ctx->resume, buf, i),
+		OWERROR_BLOCK_FAILED, FALSE );
+
+	// check verification
+	OWASSERT( ((buf[i - 1] & 0xF0) == 0x50) ||
+	          ((buf[i - 1] & 0xF0) == 0xA0),
+	         OWERROR_NO_COMPLETION_BYTE, FALSE);
+
+	return 0;
+}
+
+int
+ds1963s_client_sp_erase(struct ds1963s_client *ctx, int address)
+{
+	int portnum = ctx->copr.portnum;
+
+	/* Erase the scratchpad to clear the HIDE flag. */
+	if (EraseScratchpadSHA18(portnum, address, ctx->resume) == FALSE) {
+		ctx->errno = DS1963S_ERROR_SP_ERASE;
+		return -1;
+	}
+
+	return 0;
+}
+
+int
+ds1963s_client_sp_match(struct ds1963s_client *ctx, uint8_t hash[20])
+{
+	int ret;
+
+	assert(ctx != NULL);
+
+	ret = MatchScratchpadSHA18(ctx->copr.portnum, hash, ctx->resume);
+	if (ret == -1) {
+		ctx->errno = DS1963S_ERROR_MATCH_SCRATCHPAD;
+		return -1;
+	}
+
+	return ret == TRUE;
+}
+
+int
+ds1963s_client_sp_write(struct ds1963s_client *ctx, uint16_t address,
+                        const uint8_t *data, size_t len)
+{
+	int portnum = ctx->copr.portnum;
+	uint8_t buf[64];
+	int i = 0;
+
+	/* Make sure the data we provide fits. */
+	if (len > 32) {
+		ctx->errno = DS1963S_ERROR_DATA_LEN;
+		return -1;
+	}
+
+	if (ctx->resume) {
+		buf[i++] = ROM_CMD_RESUME;
+	} else if (__ds1963s_client_select_sha(ctx) == -1)
+		return -1;
+
+	/* write scratchpad command */
+	buf[i++] = CMD_WRITE_SCRATCHPAD;
+	/* TA1, which fully holds the offset. */
+	buf[i++] = address & 0xFF;
+	/* TA2, which is unused. */
+	buf[i++] = address >> 8;
+	/* payload */
+	memcpy(buf + i, data, len);
+
+	if (owBlock(portnum, 0, buf, len + i) == FALSE) {
+		ctx->errno = DS1963S_ERROR_TX_BLOCK;
+		return -1;
+	}
+
+	owTouchReset(portnum);
+
+	return 0;
+}
+
+int ds1963s_client_memory_read(struct ds1963s_client *ctx, uint16_t address,
+                               uint8_t *data, size_t size)
+{
+	int     portnum = ctx->copr.portnum;
+	uint8_t block[160];
+
+	if (size > sizeof(block) - 3) {
+		ctx->errno = DS1963S_ERROR_DATA_LEN;
+		return -1;
+	}
+
+	if (__ds1963s_client_select_sha(ctx) == -1)
+		return -1;
+
+	memset(block, 0xff, sizeof block);
+	/* write scratchpad command */
+	block[0] = CMD_READ_MEMORY;
+	/* TA1, which fully holds the offset. */
+	block[1] = address & 0xFF;
+	/* TA2, which is unused. */
+	block[2] = address >> 8;
+
+	OWASSERT(owBlock(portnum, 0, block, size + 3), OWERROR_BLOCK_FAILED, -1);
+	owTouchReset(portnum);
+
+	memcpy(data, &block[3], size);
+	return 0;
+}
+
+int ds1963s_client_memory_write(struct ds1963s_client *ctx, uint16_t address,
+                                const uint8_t *data, size_t size)
+{
+	int portnum = ctx->copr.portnum;
+	uint8_t buffer[32];
+	uint8_t es = 0;
+	int addr_buff;
+	int ret;
+
+	if (size > 32) {
+		ctx->errno = DS1963S_ERROR_DATA_LEN;
+		return -1;
+	}
+
+	/* Erase the scratchpad to clear the HIDE flag. */
+	if (ds1963s_client_sp_erase(ctx, 0) == -1)
+		return -1;
+
+	/* Write the provided data to the scratchpad.  This will also latch in
+ 	 * TA1 and TA2, which are validated by the copy scratchpad command.
+ 	 */
+	ret = ds1963s_client_sp_write(ctx, address, data, size);
+	if (ret == -1)
+		return -1;
+
+	/* Read back the data from the scratchpad to verify TA/ES/data. */
+	OWASSERT(ReadScratchpadSHA18(portnum, &addr_buff, &es, buffer, TRUE),
+	         OWERROR_READ_SCRATCHPAD_FAILED, -1);
+
+	/* Verify that what we read is exactly what we wrote. */
+	OWASSERT(address == addr_buff, OWERROR_READ_SCRATCHPAD_FAILED, -1);
+	OWASSERT(es + 1 == size, OWERROR_READ_SCRATCHPAD_FAILED, -1);
+	OWASSERT(memcmp(buffer, data, size) == 0,
+	         OWERROR_READ_SCRATCHPAD_FAILED, -1);
+
+	/* We latched the data to scratchpad properly, copy to memory. */
+	OWASSERT(CopyScratchpadSHA18(portnum, address, size, TRUE),
+	         OWERROR_COPY_SCRATCHPAD_FAILED, -1);
+
+	return 0;
+}
+
+static inline int
+__write_cycle_address(int write_cycle_type)
+{
+	assert(write_cycle_type >= WRITE_CYCLE_DATA_8);
+	assert(write_cycle_type <= WRITE_CYCLE_SECRET_7);
+
+	return 0x260 + write_cycle_type * 4;
+}
+
+uint32_t ds1963s_client_write_cycle_get(struct ds1963s_client *ctx, int write_cycle_type)
+{
+	int address = __write_cycle_address(write_cycle_type);
+	int portnum = ctx->copr.portnum;
+	uint8_t block[7];
+
+	if (__ds1963s_client_select_sha(ctx) == -1)
+		return (uint32_t)-1;
+
+	memset(block, 0xff, 7);
+	/* write scratchpad command */
+	block[0] = CMD_READ_MEMORY;
+	/* TA1, which fully holds the offset. */
+	block[1] = address & 0xFF;
+	/* TA2, which is unused. */
+	block[2] = address >> 8;
+
+	OWASSERT(owBlock(portnum, 0, block, 7), OWERROR_BLOCK_FAILED, FALSE);
+	owTouchReset(portnum);
+
+	return GET_32BIT_LSB(&block[3]);
+}
+
+int
+ds1963s_write_cycle_get_all(struct ds1963s_client *ctx, uint32_t counters[16])
+{
+	int address = __write_cycle_address(WRITE_CYCLE_DATA_8);
+	int portnum = ctx->copr.portnum;
+	uint8_t block[67];
+	int i;
+
+	if (__ds1963s_client_select_sha(ctx) == -1)
+		return -1;
+
+	memset(block, 0xff, sizeof block);
+	/* write scratchpad command */
+	block[0] = CMD_READ_MEMORY;
+	/* TA1, which fully holds the offset. */
+	block[1] = address & 0xFF;
+	/* TA2, which is unused. */
+	block[2] = address >> 8;
+
+	OWASSERT(owBlock(portnum, 0, block, sizeof block), OWERROR_BLOCK_FAILED, -1);
+	owTouchReset(portnum);
+
+	for (i = 0; i < 16; i++)
+		counters[i] = GET_32BIT_LSB(&block[i * 4 + 3]);
+
+	return 0;
+}
+
+uint32_t ds1963s_client_prng_get(struct ds1963s_client *ctx)
+{
+	int portnum = ctx->copr.portnum;
+	int address = 0x2A0;
+	uint8_t block[7];
+
+	if (__ds1963s_client_select_sha(ctx) == -1)
+		return (uint32_t)-1;
+
+	memset(block, 0xff, sizeof block);
+	/* write scratchpad command */
+	block[0] = CMD_READ_MEMORY;
+	/* TA1, which fully holds the offset. */
+	block[1] = address & 0xFF;
+	/* TA2, which is unused. */
+	block[2] = address >> 8;
+
+	OWASSERT(owBlock(portnum, 0, block, sizeof block), OWERROR_BLOCK_FAILED, -1);
+	owTouchReset(portnum);
+
+	return GET_32BIT_LSB(&block[3]);
+}
+
+/* Pulling down the RTS and DTR lines on the serial port for a certain
+ * amount of time power-on-resets the iButton.
+ */
+int ds1963s_client_hide_set(struct ds1963s_client *ctx)
+{
+	int status = 0;
+
+	if (ioctl(fd[ctx->copr.portnum], TIOCMSET, &status) == -1) {
+		ctx->errno = DS1963S_ERROR_SET_CONTROL_BITS;
+		return -1;
+	}
+
+	/* XXX: unclear how long we should sleep for a power-on-reset. */
+	sleep(1);
+
+	/* Release and reacquire the port. */
+	owRelease(ctx->copr.portnum);
+
+        ctx->copr.portnum = __ds1963s_acquire(ctx, ctx->device_path);
+	if (ctx->copr.portnum == -1)
+		return -1;
+
+	/* Find the DS1963S iButton again, as we've lost it after a
+	 * return to probe condition.
+	 */
+	if (__ds1963s_find(ctx, ctx->copr.portnum, ctx->copr.devAN) == -1)
+		return -1;
+
+	return 0;
+}
+
+int ds1963s_client_secret_write(struct ds1963s_client *ctx, int secret,
+                                const void *data, size_t len)
+{
+	SHACopr *copr = &ctx->copr;
+	uint8_t buf[32];
+	int secret_addr;
+	int address;
+	uint8_t es;
+
+	if (secret < 0 || secret > 7) {
+		ctx->errno = DS1963S_ERROR_SECRET_NUM;
+		return -1;
+	}
+
+	if (len > 32) {
+		ctx->errno = DS1963S_ERROR_SECRET_LEN;
+		return -1;
+	}
+
+        secret_addr = 0x200 + secret * 8;
+
+	/* Erase the scratchpad to clear the HIDE flag. */
+	if (ds1963s_client_sp_erase(ctx, 0) == -1)
+		return -1;
+
+	/* Write the secret data to the scratchpad. */ 
+	if (ds1963s_client_sp_write(ctx, 0, data, len) == -1)
+		return -1;
+
+	/* Read it back to validate it. */
+	if (ReadScratchpadSHA18(copr->portnum, &address, &es, buf, 0) == FALSE) {
+		ctx->errno = DS1963S_ERROR_SP_READ;
+		return -1;
+	}
+
+	/* Verify if we read what we wrote out. */
+	if (memcmp(buf, data, len) != 0) {
+		ctx->errno = DS1963S_ERROR_INTEGRITY;
+		return -1;
+	}
+
+	/* Now latch in TA1 and TA2 with secret_addr. */
+	if (ds1963s_client_sp_write(ctx, secret_addr, data, len) == -1)
+		return -1;
+
+	/* Read back address and es for validation. */
+	if (ReadScratchpadSHA18(copr->portnum, &address, &es, buf, 0) == FALSE) {
+		ctx->errno = DS1963S_ERROR_SP_READ;
+		return -1;
+	}
+
+	/* Set the hide flag so we can copy to the secret. */
+	if (ds1963s_client_hide_set(ctx) == -1)
+		return -1;
+
+	/* ??? */
+	if (ReadScratchpadSHA18(copr->portnum, &address, &es, buf, 0) == FALSE) {
+		ctx->errno = DS1963S_ERROR_SP_READ;
+		return -1;
+	}
+
+	/* Copy scratchpad data to the secret. */
+	if (CopyScratchpadSHA18(copr->portnum, secret_addr, len, 0) == FALSE) {
+		ctx->errno = DS1963S_ERROR_SP_COPY;
+		return -1;
+	}
+
+	return 0;
+}
+
+void
+ds1963s_client_perror(struct ds1963s_client *ctx, const char *fmt, ...)
+{
+	va_list ap;
+
+	va_start(ap, fmt);
+	ds1963s_vperror(ctx->errno, fmt, ap);
+	va_end(ap);
+}

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ds1963s-client.h
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ds1963s-client.h
@@ -1,0 +1,138 @@
+/* ds1963s-client.h
+ *
+ * A ds1963s emulation and utility framework.
+ *
+ * Dedicated to Yuzuyu Arielle Huizer.
+ *
+ * Copyright (C) 2013-2019  Ronald Huizer <rhuizer@hexpedition.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef DS1963S_CLIENT_H
+#define DS1963S_CLIENT_H
+
+#include <stdint.h>
+#include "ibutton/shaib.h"
+#include "ds1963s-error.h"
+
+#define DS1963S_HASH_SIZE		20
+#define DS1963S_PAGE_SIZE		32
+#define DS1963S_SCRATCHPAD_SIZE		32
+#define DS1963S_SERIAL_SIZE		6
+#define DS1963S_ROM_COMMAND_READ	0x33
+
+#define WRITE_CYCLE_DATA_8	0
+#define WRITE_CYCLE_DATA_9	1
+#define WRITE_CYCLE_DATA_10	2
+#define WRITE_CYCLE_DATA_11	3
+#define WRITE_CYCLE_DATA_12	4
+#define WRITE_CYCLE_DATA_13	5
+#define WRITE_CYCLE_DATA_14	6
+#define WRITE_CYCLE_DATA_15	7
+#define WRITE_CYCLE_SECRET_0	8
+#define WRITE_CYCLE_SECRET_1	9
+#define WRITE_CYCLE_SECRET_2	10
+#define WRITE_CYCLE_SECRET_3	11
+#define WRITE_CYCLE_SECRET_4	12
+#define WRITE_CYCLE_SECRET_5	13
+#define WRITE_CYCLE_SECRET_6	14
+#define WRITE_CYCLE_SECRET_7	15
+
+typedef struct ds1963s_client
+{
+	const char	*device_path;
+	SHACopr		copr;
+	int		resume;
+	int		errno;
+} ds1963s_client_t;
+
+typedef struct
+{
+	uint8_t		data[DS1963S_SCRATCHPAD_SIZE];
+	uint8_t		data_size;
+	uint16_t	address;
+	uint8_t		es;
+	uint16_t	crc16;
+	int		crc_ok;
+} ds1963s_client_sp_read_reply_t;
+
+typedef struct
+{
+	uint8_t		data[32];
+	uint8_t		data_size;
+	uint32_t	data_wc;
+	uint32_t	secret_wc;
+	uint16_t	crc16;
+	int		crc_ok;
+} ds1963s_client_read_auth_page_reply_t;
+
+typedef struct ds1963s_rom {
+	uint8_t		raw[8];
+	uint8_t		family;
+	uint8_t		serial[6];
+	uint8_t		crc;
+	int		crc_ok;
+} ds1963s_rom_t;
+
+#ifdef __cplusplus
+extern "C" {
+#endif	/* __cplusplus */
+
+int  ds1963s_client_init(struct ds1963s_client *ctx, const char *device);
+void ds1963s_client_destroy(struct ds1963s_client *ctx);
+int  ds1963s_client_page_to_address(struct ds1963s_client *ctx, int page);
+int  ds1963s_client_address_to_page(struct ds1963s_client *ctx, int address);
+
+/* Scratchpad related functions. */
+int ds1963s_client_sp_copy(ds1963s_client_t *, int address, uint8_t es);
+int ds1963s_client_sp_erase(ds1963s_client_t *, int address);
+int ds1963s_client_sp_match(ds1963s_client_t *, uint8_t hash[20]);
+int ds1963s_client_sp_read(ds1963s_client_t *, ds1963s_client_sp_read_reply_t *);
+int ds1963s_client_sp_write(ds1963s_client_t *, uint16_t address, const uint8_t *data, size_t len);
+
+int ds1963s_client_read_auth(ds1963s_client_t *, int, ds1963s_client_read_auth_page_reply_t *);
+
+/* Compute SHA commands. */
+int ds1963s_client_sha_command(ds1963s_client_t *ctx, uint8_t cmd, int address);
+int ds1963s_client_secret_compute_first(ds1963s_client_t *ctx, int address);
+int ds1963s_client_secret_compute_next(ds1963s_client_t *ctx, int address);
+int ds1963s_client_validate_data_page(ds1963s_client_t *ctx, int address);
+int ds1963s_client_sign_data_page(ds1963s_client_t *ctx, int address);
+int ds1963s_client_compute_challenge(ds1963s_client_t *ctx, int address);
+int ds1963s_client_authenticate_host(ds1963s_client_t *ctx, int address);
+
+void ds1963s_client_rom_get(ds1963s_client_t *, ds1963s_rom_t *);
+int  ds1963s_client_taes_get(struct ds1963s_client *ctx, uint16_t *addr, uint8_t *es);
+int  ds1963s_client_taes_print(struct ds1963s_client *ctx);
+void ds1963s_client_hash_print(uint8_t hash[20]);
+
+int ds1963s_client_memory_read(struct ds1963s_client *ctx, uint16_t address,
+                               uint8_t *data, size_t size);
+int ds1963s_client_memory_write(struct ds1963s_client *ctx, uint16_t address,
+                                const uint8_t *data, size_t size);
+uint32_t ds1963s_client_prng_get(struct ds1963s_client *ctx);
+
+void ds1963s_client_perror(struct ds1963s_client *ctx, const char *s, ...);
+int ds1963s_write_cycle_get_all(struct ds1963s_client*, uint32_t [16]);
+int ds1963s_client_hide_set(struct ds1963s_client *ctx);
+
+int ds1963s_client_secret_write(struct ds1963s_client *ctx, int secret,
+                                const void *data, size_t len);
+int ds1963s_client_hash_read(struct ds1963s_client *ctx, uint8_t hash[20]);
+
+#ifdef __cplusplus
+};
+#endif	/* __cplusplus */
+
+#endif	/* !DS1963S_CLIENT_H */

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ds1963s-common.c
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ds1963s-common.c
@@ -1,0 +1,196 @@
+/* ds1963s-common.c
+ *
+ * A ds1963s emulation and utility framework.
+ *
+ * Dedicated to Yuzuyu Arielle Huizer.
+ *
+ * Copyright (C) 2016-2019  Ronald Huizer <rhuizer@hexpedition.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include <assert.h>
+#include <stddef.h>
+#include <string.h>
+#include <ctype.h>
+#include <inttypes.h>
+#include "ds1963s-common.h"
+
+static uint8_t ds1963s_crc8_table[] = {
+	0, 94,188,226, 97, 63,221,131,194,156,126, 32,163,253, 31, 65,
+      157,195, 33,127,252,162, 64, 30, 95,  1,227,189, 62, 96,130,220,
+       35,125,159,193, 66, 28,254,160,225,191, 93,  3,128,222, 60, 98,
+      190,224,  2, 92,223,129, 99, 61,124, 34,192,158, 29, 67,161,255,
+       70, 24,250,164, 39,121,155,197,132,218, 56,102,229,187, 89,  7,
+      219,133,103, 57,186,228,  6, 88, 25, 71,165,251,120, 38,196,154,
+      101, 59,217,135,  4, 90,184,230,167,249, 27, 69,198,152,122, 36,
+      248,166, 68, 26,153,199, 37,123, 58,100,134,216, 91,  5,231,185,
+      140,210, 48,110,237,179, 81, 15, 78, 16,242,172, 47,113,147,205,
+       17, 79,173,243,112, 46,204,146,211,141,111, 49,178,236, 14, 80,
+      175,241, 19, 77,206,144,114, 44,109, 51,209,143, 12, 82,176,238,
+       50,108,142,208, 83, 13,239,177,240,174, 76, 18,145,207, 45,115,
+      202,148,118, 40,171,245, 23, 73,  8, 86,180,234,105, 55,213,139,
+       87,  9,235,181, 54,104,138,212,149,203, 41,119,244,170, 72, 22,
+      233,183, 85, 11,136,214, 52,106, 43,117,151,201, 74, 20,246,168,
+      116, 42,200,150, 21, 75,169,247,182,232, 10, 84,215,137,107, 53
+};
+
+uint8_t ds1963s_crc8(const uint8_t *buf, size_t count)
+{
+	uint8_t crc = 0;
+	size_t i;
+
+	for (i = 0; i < count; i++)
+		crc = ds1963s_crc8_table[crc ^ buf[i]];
+
+	return crc;
+}
+
+static uint8_t oddparity[16] = { 0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0 };
+
+uint16_t
+ds1963s_crc16_update(uint16_t crc16, const uint8_t *buf, size_t count)
+{
+	uint16_t crc = crc16;
+	uint16_t word;
+	size_t i;
+
+	for (i = 0; i < count; i++) {
+		word = (crc ^ buf[i]) & 0xFF;
+		crc >>= 8;
+
+		if (oddparity[word & 0xf] ^ oddparity[word >> 4])
+			crc ^= 0xc001;
+
+		word <<= 6;
+		crc ^= word;
+		word <<= 1;
+		crc ^= word;
+	}
+
+	return crc;
+}
+
+uint16_t
+ds1963s_crc16_update_byte(uint16_t crc16, uint8_t byte)
+{
+	return ds1963s_crc16_update(crc16, &byte, 1);
+}
+
+uint16_t
+ds1963s_crc16(const uint8_t *buf, size_t count)
+{
+	return ds1963s_crc16_update(0, buf, count);
+}
+
+uint16_t
+ds1963s_ta_to_address(uint8_t TA1, uint8_t TA2)
+{
+        return (TA2 << 8) | TA1;
+}
+
+void
+ds1963s_address_to_ta(uint16_t address, uint8_t *TA1, uint8_t *TA2)
+{
+	*TA1 = address & 0xFF;
+	*TA2 = address >> 8;
+}
+
+int
+ds1963s_address_to_page(int address)
+{
+        if (address < 0 || address >= 0x400)
+                return -1;
+
+        return address / 32;
+}
+
+int
+ds1963s_address_secret(int address)
+{
+	return address >= 0x200 && address <= 0x23F;
+}
+
+static inline int
+__dehex_char(char c)
+{
+	if (c >= '0' && c <= '9')
+		return c - '0';
+
+	c = tolower(c);
+
+	if (c >= 'a' && c <= 'f')
+		return 10 + c - 'a';
+
+	return -1;
+}
+
+ssize_t
+hex_decode(uint8_t *dst, const char *src, size_t n)
+{
+	size_t src_len = strlen(src);
+	size_t i, j;
+
+	if (src_len == 0 || src_len % 2 != 0)
+		return -1;
+
+	for (i = 0; i < src_len; i++)
+		if (!isxdigit(src[i]))
+			return -1;
+
+	for (i = j = 0; i < src_len - 1 && j < n; i += 2, j++)
+		dst[j] = __dehex_char(src[i]) * 16 + __dehex_char(src[i + 1]);
+
+	return j;
+}
+
+void
+fhexdump(FILE *fp, uint8_t *p, size_t n, uint64_t offset)
+{
+	assert(fp != NULL);
+	assert(p != NULL);
+
+	if (n == 0)
+		return;
+
+	while (n != 0) {
+		char buf[17] = { 0 };
+		int  i;
+
+		fprintf(fp, "%.8" PRIx64 ":", offset);
+		for (i = 0; i < 16; i++, offset++) {
+			if (i % 2 == 0)
+				fprintf(fp, " ");
+
+			if (n != 0)  {
+				n = n - 1;
+				if (*p >= 0x20 && *p <= 0x7E)
+					buf[i] = *p;
+				else
+					buf[i] = '.';
+
+				fprintf(fp, "%.2x", *p++);
+			} else {
+				fprintf(fp, "  ");
+			}
+		}
+
+		fprintf(fp, "  %s\n", buf);
+	}
+}
+
+void
+hexdump(uint8_t *p, size_t n, uint64_t offset)
+{
+	fhexdump(stdout, p, n, offset);
+}

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ds1963s-common.h
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ds1963s-common.h
@@ -1,0 +1,50 @@
+/* ds1963s-common.h
+ *
+ * A ds1963s emulation and utility framework.
+ *
+ * Dedicated to Yuzuyu Arielle Huizer.
+ *
+ * Copyright (C) 2016-2019  Ronald Huizer <rhuizer@hexpedition.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef DS1963S_COMMON_H
+#define DS1963S_COMMON_H
+
+#include <stdio.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+uint8_t  ds1963s_crc8(const uint8_t *buf, size_t count);
+uint16_t ds1963s_crc16(const uint8_t *buf, size_t count);
+uint16_t ds1963s_crc16_update(uint16_t crc16, const uint8_t *buf, size_t count);
+uint16_t ds1963s_crc16_update_byte(uint16_t crc16, uint8_t byte);
+
+uint16_t ds1963s_ta_to_address(uint8_t TA1, uint8_t TA2);
+void     ds1963s_address_to_ta(uint16_t address, uint8_t *TA1, uint8_t *TA2);
+int      ds1963s_address_to_page(int address);
+int      ds1963s_address_secret(int address);
+
+ssize_t  hex_decode(uint8_t *dst, const char *src, size_t n);
+void     hexdump(uint8_t *s, size_t n, uint64_t offset);
+void     fhexdump(FILE *fp, uint8_t *s, size_t n, uint64_t offset);
+
+#ifdef __cplusplus
+};
+#endif
+
+#endif

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ds1963s-device.c
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ds1963s-device.c
@@ -1,0 +1,1228 @@
+/* ds1963s-device.c
+ *
+ * A software implementation of the DS1963S iButton.
+ *
+ * Dedicated to Yuzuyu Arielle Huizer.
+ *
+ * Copyright (C) 2016-2019  Ronald Huizer <rhuizer@hexpedition.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include "ds1963s-common.h"
+#include "ds1963s-device.h"
+#include "getput.h"
+#include "sha1.h"
+
+#define DS1963S_TX_BIT(dev, bit)					\
+	({								\
+		int v;							\
+									\
+		v = one_wire_bus_member_tx_bit(&dev->bus_slave, bit);	\
+		if (v == ONE_WIRE_BUS_SIGNAL_RESET) {			\
+			__ds1963s_dev_do_reset_pulse(dev);		\
+			return ONE_WIRE_BUS_SIGNAL_RESET;		\
+		} else if (v == ONE_WIRE_BUS_SIGNAL_TERMINATE) {	\
+			dev->state = DS1963S_STATE_TERMINATED;		\
+			return ONE_WIRE_BUS_SIGNAL_TERMINATE;		\
+		}							\
+									\
+		v;							\
+	})
+
+#define DS1963S_TX_BYTE(dev, byte)					\
+	({								\
+		int v;							\
+									\
+		v = one_wire_bus_member_tx_byte(&dev->bus_slave, byte);	\
+		if (v == ONE_WIRE_BUS_SIGNAL_RESET) {			\
+			__ds1963s_dev_do_reset_pulse(dev);		\
+			return ONE_WIRE_BUS_SIGNAL_RESET;		\
+		} else if (v == ONE_WIRE_BUS_SIGNAL_TERMINATE) {	\
+			dev->state = DS1963S_STATE_TERMINATED;		\
+			return ONE_WIRE_BUS_SIGNAL_TERMINATE;		\
+		}							\
+									\
+		v;							\
+	})
+
+#define DS1963S_TX_FAIL(dev)						\
+	do {								\
+		DS1963S_TX_BIT(dev, 1);					\
+	} while (1)
+
+#define DS1963S_TX_SUCCESS(dev)						\
+	do {								\
+		DS1963S_TX_BIT(dev, 0);					\
+		DS1963S_TX_BIT(dev, 1);					\
+	} while (1)
+
+#define DS1963S_TX_END(dev)	DS1963S_TX_FAIL(dev)
+#define DS1963S_RX_BIT(dev)	DS1963S_TX_BIT(dev, 1)
+#define DS1963S_RX_BYTE(dev)	DS1963S_TX_BYTE(dev, 0xFF)
+
+/* Calculate the value for MPX, as used in __sha1_get_input_1. */
+static uint8_t
+__mpx_get(int M, int X, uint8_t *SP)
+{
+	return (M << 7) | (X << 6) | (SP[12] & 0x3F);
+}
+
+/* Calculate the value for MP, as used in __sha1_get_input_2. */
+static uint8_t
+__mp_get(int M, int X, int page)
+{
+	return (M << 7) | (X << 6) | (page & 0xF);
+}
+
+/* Construct the SHA-1 input for the following operations:
+ *
+ * - Validate Data Page
+ * - Sign Data Page
+ * - Authenticate Host
+ * - Compute First Secret
+ * - Compute Next Secret
+ */
+static void
+__sha1_get_input_1(uint8_t M[64], uint8_t *SS, uint8_t *PP, uint8_t MPX,
+                   uint8_t *SP)
+{
+	memcpy(&M[ 0], &SS[ 0],  4);
+	memcpy(&M[ 4], &PP[ 0], 32);
+	memcpy(&M[36], &SP[ 8],  4);
+	M[40] = MPX;
+	memcpy(&M[41], &SP[13],  7);
+	memcpy(&M[48], &SS[ 4],  4);
+	memcpy(&M[52], &SP[20],  3);
+	M[55] = 0x80;
+	M[56] = 0;
+	M[57] = 0;
+	M[58] = 0;
+	M[59] = 0;
+	M[60] = 0;
+	M[61] = 0;
+	M[62] = 1;
+	M[63] = 0xB8;
+}
+
+/* Construct the SHA-1 input for the following operations:
+ *
+ * - Read Authenticated Page
+ * - Compute Challenge
+ */
+static void
+__sha1_get_input_2(uint8_t M[64], uint8_t *SS, uint8_t *CC, uint8_t *PP,
+                   uint8_t FAMC, uint8_t MP, uint8_t *SN, uint8_t *SP)
+{
+	memcpy(&M[ 0], &SS[ 0],  4);
+	memcpy(&M[ 4], &PP[ 0], 32);
+	memcpy(&M[36], &CC[ 0],  4);
+	M[40] = MP;
+	M[41] = FAMC;
+	memcpy(&M[42], &SN[ 0],  6);
+	memcpy(&M[48], &SS[ 4],  4);
+	memcpy(&M[52], &SP[20],  3);
+	M[55] = 0x80;
+	M[56] = 0;
+	M[57] = 0;
+	M[58] = 0;
+	M[59] = 0;
+	M[60] = 0;
+	M[61] = 0;
+	M[62] = 1;
+	M[63] = 0xB8;
+}
+
+/* Construct the SHA-1 output for all operation except:
+ *
+ * - Compute First Secret
+ * - Compute Next Secret
+ */
+static void
+__sha1_get_output_1(uint8_t SP[32], uint32_t A, uint32_t B, uint32_t C,
+                    uint32_t D, uint32_t E)
+{
+	SP[ 8] = (E >>  0) & 0xFF;
+	SP[ 9] = (E >>  8) & 0xFF;
+	SP[10] = (E >> 16) & 0xFF;
+	SP[11] = (E >> 24) & 0xFF;
+
+	SP[12] = (D >>  0) & 0xFF;
+	SP[13] = (D >>  8) & 0xFF;
+	SP[14] = (D >> 16) & 0xFF;
+	SP[15] = (D >> 24) & 0xFF;
+
+	SP[16] = (C >>  0) & 0xFF;
+	SP[17] = (C >>  8) & 0xFF;
+	SP[18] = (C >> 16) & 0xFF;
+	SP[19] = (C >> 24) & 0xFF;
+
+	SP[20] = (B >>  0) & 0xFF;
+	SP[21] = (B >>  8) & 0xFF;
+	SP[22] = (B >> 16) & 0xFF;
+	SP[23] = (B >> 24) & 0xFF;
+
+	SP[24] = (A >>  0) & 0xFF;
+	SP[25] = (A >>  8) & 0xFF;
+	SP[26] = (A >> 16) & 0xFF;
+	SP[27] = (A >> 24) & 0xFF;
+}
+
+/* Construct the SHA-1 output for operations:
+ *
+ * - Compute First Secret
+ * - Compute Next Secret
+ */
+static void
+__sha1_get_output_2(uint8_t SP[32], uint32_t D, uint32_t E)
+{
+	for (int i = 0; i < 32; i += 8) {
+		SP[i + 0] = (E >>  0) & 0xFF;
+		SP[i + 1] = (E >>  8) & 0xFF;
+		SP[i + 2] = (E >> 16) & 0xFF;
+		SP[i + 3] = (E >> 24) & 0xFF;
+
+		SP[i + 4] = (D >>  0) & 0xFF;
+		SP[i + 5] = (D >>  8) & 0xFF;
+		SP[i + 6] = (D >> 16) & 0xFF;
+		SP[i + 7] = (D >> 24) & 0xFF;
+	}
+}
+
+static inline void
+__ds1963s_dev_do_reset_pulse(struct ds1963s_device *dev)
+{
+	DEBUG_LOG("[ds1963s] got reset pulse\n");
+	dev->state = DS1963S_STATE_RESET;
+}
+
+void ds1963s_dev_init(struct ds1963s_device *ds1963s)
+{
+	memset(ds1963s, 0, sizeof *ds1963s);
+
+	ds1963s->family = DS1963S_DEVICE_FAMILY;
+	ds1963s->ES     = 0x1f;
+	memset(ds1963s->data_memory,   0xaa, sizeof ds1963s->data_memory);
+	memset(ds1963s->secret_memory, 0xaa, sizeof ds1963s->secret_memory);
+	memset(ds1963s->scratchpad,    0xff, sizeof ds1963s->scratchpad);
+
+	one_wire_bus_member_init(&ds1963s->bus_slave);
+        ds1963s->bus_slave.device = (void *)ds1963s;
+        ds1963s->bus_slave.driver = (void(*)(void *))ds1963s_dev_power_on;
+
+#ifdef DEBUG
+	strncpy(ds1963s->bus_slave.name, "ds1963s", sizeof ds1963s->bus_slave.name);
+#endif
+}
+
+void ds1963s_dev_destroy(struct ds1963s_device *ds1963s)
+{
+	assert(ds1963s != NULL);
+
+	list_del(&ds1963s->bus_slave.list_entry);
+	memset(ds1963s, 0, sizeof *ds1963s);
+}
+
+int
+ds1963s_dev_pf_get(struct ds1963s_device *dev)
+{
+	return (dev->ES >> 5) & 1;
+}
+
+void
+ds1963s_dev_pf_set(struct ds1963s_device *dev, int pf)
+{
+	dev->ES &= ~(1 << 5);
+	dev->ES |= pf << 5;
+}
+
+uint16_t
+ds1963s_dev_address_get(struct ds1963s_device *dev)
+{
+	return ds1963s_ta_to_address(dev->TA1, dev->TA2) % 0x400;
+}
+
+int
+ds1963s_dev_page_get(struct ds1963s_device *dev)
+{
+	return ds1963s_address_to_page(ds1963s_dev_address_get(dev));
+}
+
+void
+ds1963s_dev_rom_code_get(struct ds1963s_device *ds1963s, uint8_t buf[8])
+{
+	buf[0] = ds1963s->family;
+	memcpy(&buf[1], ds1963s->serial, 6);
+	buf[7] = ds1963s_crc8(buf, 7);
+}
+
+void ds1963s_dev_connect_bus(struct ds1963s_device *ds1963s, struct one_wire_bus *bus)
+{
+	assert(ds1963s != NULL);
+
+	one_wire_bus_member_add(&ds1963s->bus_slave, bus);
+}
+
+void ds1963s_dev_erase_scratchpad(struct ds1963s_device *dev, int address)
+{
+	assert(dev != NULL);
+	assert(address >= 0 && address <= 65536);
+
+	dev->CHLG = 0;
+	dev->AUTH = 0;
+	dev->TA1  = address & 0xFF;
+	dev->TA2  = (address >> 8) & 0xFF;
+	dev->ES   = 0x1f;
+
+	memset(dev->scratchpad, 0xFF, sizeof dev->scratchpad);
+
+	dev->HIDE = 0;
+}
+
+void ds1963s_dev_write_scratchpad(
+	struct ds1963s_device *ds1963s,
+	int address,
+	const unsigned char *data,
+	size_t len
+) {
+	assert(ds1963s != NULL);
+	assert(address >= 0 && address <= 65536);
+	assert(data != NULL);
+
+	ds1963s->CHLG = 0;
+	ds1963s->AUTH = 0;
+	ds1963s->TA1  = address & 0xFF;
+	ds1963s->TA2  = (address >> 8) & 0xFF;
+
+	if (ds1963s->HIDE == 1) {
+		/* XXX: test for secret address. */
+
+		/* PF := 0; AA := 0 */
+		ds1963s->ES &= 0x5F;
+
+		/* T2:T0 := 0,0,0 */
+		ds1963s->TA1 &= 0xF8;
+
+		/* E4:E0 := T4, T3, 0, 0, 0 */
+		ds1963s->ES &= 0xE0;                /* E4:E0 := 0,0,0,0,0 */
+		ds1963s->ES |= ds1963s->TA1 & 0x1F; /* E4:E0 := T4:T0     */
+		ds1963s->ES |= 0x07;                /* E2:E0 := 1,1,1     */
+	} else {
+
+	}
+}
+
+static void
+__ds1963s_dev_compute_secret(struct ds1963s_device *dev, uint8_t secret[8])
+{
+	uint8_t  M[64];
+	uint16_t addr;
+	int      page;
+	uint8_t  *SS;
+	SHA1_CTX ctx;
+
+	assert(dev != NULL);
+
+	SS         = secret;
+	dev->ES   |= 0x1F;	/* E4:E0 := 1,1,1,1,1 */
+	dev->M     = 0;
+	dev->X     = 0;
+	dev->HIDE  = 1;
+	dev->CHLG  = 0;
+	dev->AUTH  = 0;
+	dev->MATCH = 0;
+
+	/* XXX: unclear of the ds1963s page aligns all this or just uses
+	 * the address.  Test later.
+	 */
+	addr = ds1963s_ta_to_address(dev->TA1, dev->TA2);
+	page = ds1963s_address_to_page(addr);
+
+	__sha1_get_input_1(
+		M,
+		SS,
+		&dev->data_memory[(page % 16) * 32],
+		__mpx_get(dev->M, dev->X, dev->scratchpad),
+		dev->scratchpad
+	);
+
+	/* We omit the finalize, as the DS1963S does not use it, but rather
+	 * uses the internal state A, B, C, D, E for the result.  This also
+	 * means we have to subtract the initial state from the context, as
+	 * it has added these to the results.
+	 */
+	SHA1_Init(&ctx);
+	SHA1_Update(&ctx, M, sizeof M);
+
+	/* Write the results to the scratchpad. */
+	__sha1_get_output_2(
+		dev->scratchpad,
+		ctx.state[3] - 0x10325476,
+		ctx.state[4] - 0xC3D2E1F0
+	);
+
+	dev->prng_counter++;
+}
+
+void
+ds1963s_dev_compute_first_secret(struct ds1963s_device *dev)
+{
+	uint8_t secret[8] = { 0 };
+	__ds1963s_dev_compute_secret(dev, secret);
+}
+
+void
+ds1963s_dev_compute_next_secret(struct ds1963s_device *dev)
+{
+	int addr, page;
+
+	/* Check the page this address belongs to. */
+	addr = ds1963s_ta_to_address(dev->TA1, dev->TA2);
+	page = ds1963s_address_to_page(addr);
+
+	__ds1963s_dev_compute_secret(dev, &dev->secret_memory[(page % 8) * 8]);
+}
+
+void
+ds1963s_dev_read_auth_page(struct ds1963s_device *dev, int page)
+{
+	uint8_t M[64];
+	uint8_t CC[4];
+	SHA1_CTX ctx;
+
+	PUT_32BIT_LSB(CC, dev->data_wc[page]);
+
+	__sha1_get_input_2(
+		M,
+		&dev->secret_memory[(page % 8) * 8],
+		CC,
+		&dev->data_memory[(page % 16) * 32],
+		DS1963S_DEVICE_FAMILY,
+		__mp_get(dev->M, dev->X, page),
+		dev->serial,
+		dev->scratchpad
+	);
+
+	/* We omit the finalize, as the DS1963S does not use it, but rather
+	 * uses the internal state A, B, C, D, E for the result.  This also
+	 * means we have to subtract the initial state from the context, as
+	 * it has added these to the results.
+	 */
+	SHA1_Init(&ctx);
+	SHA1_Update(&ctx, M, sizeof M);
+
+	/* Write the results to the scratchpad. */
+	__sha1_get_output_1(
+		dev->scratchpad,
+		ctx.state[0] - 0x67452301,
+		ctx.state[1] - 0xEFCDAB89,
+		ctx.state[2] - 0x98BADCFE,
+		ctx.state[3] - 0x10325476,
+		ctx.state[4] - 0xC3D2E1F0
+	);
+
+	dev->prng_counter++;
+}
+
+static int
+__ds1963s_dev_sign_data_page(struct ds1963s_device *dev)
+{
+	uint8_t  M[64];
+	int      page;
+	SHA1_CTX ctx;
+
+	assert(dev != NULL);
+
+	/* XXX: fix M handling later. */
+	dev->M    = 0;
+
+	dev->X    = 0;
+	dev->CHLG = 0;
+	dev->AUTH = 0;
+
+	/* The specifications state T4:T0 = 00000b, but this is not actually
+	 * set in the TA1 register, as can be verified with ds1963s-shell.
+	 * We will align the address used down ourselves in the SHA input.
+	 */
+	page = ds1963s_dev_page_get(dev);
+
+	__sha1_get_input_1(
+		M,
+		&dev->secret_memory[(page % 8) * 8],
+		&dev->memory[page * 32],
+		__mpx_get(dev->M, dev->X, dev->scratchpad),
+		dev->scratchpad
+	);
+
+	/* We omit the finalize, as the DS1963S does not use it, but rather
+	 * uses the internal state A, B, C, D, E for the result.  This also
+	 * means we have to subtract the initial state from the context, as
+	 * it has added these to the results.
+	 */
+	SHA1_Init(&ctx);
+	SHA1_Update(&ctx, M, sizeof M);
+
+	/* Write the results to the scratchpad. */
+	__sha1_get_output_1(
+		dev->scratchpad,
+		ctx.state[0] - 0x67452301,
+		ctx.state[1] - 0xEFCDAB89,
+		ctx.state[2] - 0x98BADCFE,
+		ctx.state[3] - 0x10325476,
+		ctx.state[4] - 0xC3D2E1F0
+	);
+
+	dev->prng_counter++;
+
+	return 0;
+}
+
+int
+ds1963s_dev_sign_data_page(struct ds1963s_device *dev)
+{
+	uint16_t addr;
+	int      page;
+
+	assert(dev != NULL);
+
+	addr = ds1963s_ta_to_address(dev->TA1, dev->TA2);
+	page = ds1963s_address_to_page(addr);
+
+	if (page != 0 && page != 8)
+		return -1;
+
+	return __ds1963s_dev_sign_data_page(dev);
+}
+
+int
+ds1963s_dev_compute_challenge(struct ds1963s_device *dev)
+{
+	uint8_t  M[64];
+	uint8_t  CC[4];
+	int      page;
+	SHA1_CTX ctx;
+
+	/* The specifications state T4:T0 = 00000b, but this is not actually
+	 * set in the TA1 register, as can be verified with ds1963s-shell.
+	 * We will align the address used down ourselves in the SHA input.
+	 */
+	dev->M     = 0;
+	dev->X     = 1;
+	dev->CHLG  = 1;
+	dev->AUTH  = 0;
+	dev->MATCH = 0;
+
+	PUT_32BIT_LSB(CC, dev->prng_counter);
+	page = ds1963s_dev_page_get(dev);
+
+	__sha1_get_input_2(
+		M,
+		&dev->secret_memory[(page % 8) * 8],
+		CC,
+		&dev->data_memory[(page % 16) * 32],
+		DS1963S_DEVICE_FAMILY,
+		__mp_get(dev->M, dev->X, page),
+		dev->serial,
+		dev->scratchpad
+	);
+
+	/* We omit the finalize, as the DS1963S does not use it, but rather
+	 * uses the internal state A, B, C, D, E for the result.  This also
+	 * means we have to subtract the initial state from the context, as
+	 * it has added these to the results.
+	 */
+	SHA1_Init(&ctx);
+	SHA1_Update(&ctx, M, sizeof M);
+
+	/* Write the results to the scratchpad. */
+	__sha1_get_output_1(
+		dev->scratchpad,
+		ctx.state[0] - 0x67452301,
+		ctx.state[1] - 0xEFCDAB89,
+		ctx.state[2] - 0x98BADCFE,
+		ctx.state[3] - 0x10325476,
+		ctx.state[4] - 0xC3D2E1F0
+	);
+
+	dev->prng_counter++;
+
+	return 0;
+}
+
+int
+ds1963s_dev_authenticate_host(struct ds1963s_device *dev)
+{
+	uint8_t  M[64];
+	int      page;
+	SHA1_CTX ctx;
+
+	assert(dev != NULL);
+
+	dev->M     = 0;
+	dev->X     = 1;
+	dev->HIDE  = 1;
+	dev->MATCH = 0;
+
+	page = ds1963s_dev_page_get(dev);
+
+	__sha1_get_input_1(
+		M,
+		&dev->secret_memory[(page % 8) * 8],
+		&dev->memory[page * 32],
+		__mpx_get(dev->M, dev->X, dev->scratchpad),
+		dev->scratchpad
+	);
+
+	/* We omit the finalize, as the DS1963S does not use it, but rather
+	 * uses the internal state A, B, C, D, E for the result.  This also
+	 * means we have to subtract the initial state from the context, as
+	 * it has added these to the results.
+	 */
+	SHA1_Init(&ctx);
+	SHA1_Update(&ctx, M, sizeof M);
+
+	/* Write the results to the scratchpad. */
+	__sha1_get_output_1(
+		dev->scratchpad,
+		ctx.state[0] - 0x67452301,
+		ctx.state[1] - 0xEFCDAB89,
+		ctx.state[2] - 0x98BADCFE,
+		ctx.state[3] - 0x10325476,
+		ctx.state[4] - 0xC3D2E1F0
+	);
+
+	dev->prng_counter++;
+
+	if (dev->CHLG == 1) {
+		/* XXX: FIXME */
+		dev->AUTH = 1;
+		dev->CHLG = 0;
+	}
+
+	return 0;
+}
+
+int
+ds1963s_dev_validate_data_page(struct ds1963s_device *dev)
+{
+	assert(dev != NULL);
+
+	dev->HIDE = 1;
+	return __ds1963s_dev_sign_data_page(dev);
+}
+
+void
+ds1963s_dev_rom_command_resume(struct ds1963s_device *dev)
+{
+	if (dev->RC == 1)
+		dev->state = DS1963S_STATE_MEMORY_FUNCTION;
+	else
+		dev->state = DS1963S_STATE_RESET_WAIT;
+}
+
+int
+ds1963s_dev_rom_command_search_rom(struct ds1963s_device *dev)
+{
+	uint8_t rom_code[8];
+
+	dev->RC = 0;
+	ds1963s_dev_rom_code_get(dev, rom_code);
+
+	for (int i = 0; i < sizeof(rom_code); i++) {
+		for (int j = 0; j < 8; j++) {
+			int mb;
+			int b1 = (rom_code[i] >> j) & 1;
+			int b2 = !b1;
+
+			DS1963S_TX_BIT(dev, b1);
+			DS1963S_TX_BIT(dev, b2);
+			mb = DS1963S_RX_BIT(dev);
+			DEBUG_LOG("search rom bit #%d: %d\n", i * 8 + j, mb);
+
+			/* Special case.  On mismatch we wait for reset. */
+			if (mb != b1) {
+				DEBUG_LOG("mismatch: expected %d got %d\n", b1, mb);
+				dev->state = DS1963S_STATE_RESET_WAIT;
+				return -1;
+			}
+		}
+	}
+
+	DEBUG_LOG("search rom match\n");
+	dev->RC = 1;
+
+	return 0;
+}
+
+int
+ds1963s_dev_rom_function(struct ds1963s_device *dev)
+{
+	int byte;
+
+	byte = DS1963S_RX_BYTE(dev);
+
+	switch (byte) {
+	case 0x33:
+		DEBUG_LOG("[ds1963s|ROM] Read ROM Command\n");
+		fprintf(stderr, "Read ROM Command is not supported\n");
+		exit(EXIT_FAILURE);
+	case 0x3C:
+		DEBUG_LOG("[ds1963s|ROM] Overdrive skip ROM\n");
+		dev->RC = 0;
+		dev->OD = 1;
+		break;
+	case 0x55:
+		DEBUG_LOG("[ds1963s|ROM] Match ROM Command\n");
+		fprintf(stderr, "Match ROM Command is not supported\n");
+		exit(EXIT_FAILURE);
+	case 0x69:
+		DEBUG_LOG("[ds1963s|ROM] Overdrive Match Command\n");
+		fprintf(stderr, "Overdrive Match Command is not supported\n");
+		exit(EXIT_FAILURE);
+	case 0xA5:
+		DEBUG_LOG("[ds1963s|ROM] Resume\n");
+		ds1963s_dev_rom_command_resume(dev);
+		break;
+	case 0xCC:
+		DEBUG_LOG("[ds1963s|ROM] Skip ROM Command\n");
+		dev->RC = 0;
+		break;
+	case 0xF0:
+		DEBUG_LOG("[ds1963s|ROM] Search ROM\n");
+		if (ds1963s_dev_rom_command_search_rom(dev) == -1)
+			return -1;
+
+		dev->state = DS1963S_STATE_MEMORY_FUNCTION;
+		break;
+	default:
+		DEBUG_LOG("[ds1963s|ROM] Unknown command %.2x\n", byte);
+		break;
+	}
+
+	return 0;
+}
+
+int
+ds1963s_dev_memory_command_write_scratchpad(struct ds1963s_device *dev)
+{
+	uint8_t  offset;
+	uint16_t crc16;
+	uint16_t addr;
+
+	dev->CHLG = 0;
+	dev->AUTH = 0;
+	dev->TA1  = DS1963S_RX_BYTE(dev);
+	dev->TA2  = DS1963S_RX_BYTE(dev);
+	addr      = ds1963s_ta_to_address(dev->TA1, dev->TA2);
+	offset    = dev->TA1 & 0x1F;
+
+	crc16 = 0;
+	crc16 = ds1963s_crc16_update_byte(crc16, 0x0F);
+	crc16 = ds1963s_crc16_update_byte(crc16, dev->TA1);
+	crc16 = ds1963s_crc16_update_byte(crc16, dev->TA2);
+
+	if (dev->HIDE == 0) {
+		if (addr >= 0x200) goto done;
+		dev->ES &= 0x5F;		/* PF := 0; AA := 0 */
+	} else {
+		if (!ds1963s_address_secret(addr)) goto done;
+		dev->ES  &= 0x5F;		/* PF := 0; AA := 0 */
+		dev->TA1 &= 0xF8;		/* T2:T0 := 0,0,0 */
+		dev->ES  &= 0xE0;		/* E4:E0 := 0,0,0,0,0 */
+		dev->ES  |= dev->TA1 & 0x1F;	/* E4:E0 := T4:T0     */
+		dev->ES  |= 0x07;		/* E2:E0 := 1,1,1     */
+	}
+
+	for (int i = 3; offset < 32; i++, offset++) {
+		int byte;
+
+		/* XXX: does not properly handle 8-bit boundaries. */
+		byte = one_wire_bus_member_rx_byte(&dev->bus_slave);
+		if (byte == ONE_WIRE_BUS_SIGNAL_RESET) {
+			__ds1963s_dev_do_reset_pulse(dev);
+			dev->PF = 1;
+			return ONE_WIRE_BUS_SIGNAL_RESET;
+		}
+
+		if (dev->HIDE == 0)
+			dev->scratchpad[offset] = byte;
+
+		crc16 = ds1963s_crc16_update_byte(crc16, byte);
+	}
+
+	/* If the full scratchpad was written we send the crc16. */
+	if (offset == 32) {
+		crc16 = ~crc16;
+		DS1963S_TX_BYTE(dev, crc16 & 0xFF);
+		DS1963S_TX_BYTE(dev, crc16 >> 8);
+	}
+
+done:
+	DS1963S_TX_END(dev);
+}
+
+int
+ds1963s_dev_sha_command_compute_first_secret(struct ds1963s_device *dev)
+{
+	ds1963s_dev_compute_first_secret(dev);
+
+	/* XXX: Investigate how many 1s to send later. */
+	for (int i = 0; i < 10; i++)
+		DS1963S_TX_BIT(dev, 1);
+
+	DS1963S_TX_SUCCESS(dev);
+}
+
+
+int
+ds1963s_dev_sha_command_compute_next_secret(struct ds1963s_device *dev)
+{
+	ds1963s_dev_compute_next_secret(dev);
+
+	/* XXX: Investigate how many 1s to send later. */
+	for (int i = 0; i < 10; i++)
+		DS1963S_TX_BIT(dev, 1);
+
+	DS1963S_TX_SUCCESS(dev);
+}
+
+int
+ds1963s_dev_sha_command_validate_data_page(struct ds1963s_device *dev)
+{
+	if (ds1963s_dev_validate_data_page(dev) == -1)
+		DS1963S_TX_FAIL(dev);
+
+	/* XXX: Investigate how many 1s to send later. */
+	for (int i = 0; i < 10; i++)
+		DS1963S_TX_BIT(dev, 1);
+
+	DS1963S_TX_SUCCESS(dev);
+}
+
+int
+ds1963s_dev_sha_command_sign_data_page(struct ds1963s_device *dev)
+{
+	if (ds1963s_dev_sign_data_page(dev) == -1)
+		DS1963S_TX_FAIL(dev);
+
+	/* XXX: Investigate how many 1s to send later. */
+	for (int i = 0; i < 10; i++)
+		DS1963S_TX_BIT(dev, 1);
+
+	DS1963S_TX_SUCCESS(dev);
+}
+
+
+int
+ds1963s_dev_sha_command_compute_challenge(struct ds1963s_device *dev)
+{
+	if (ds1963s_dev_compute_challenge(dev) == -1)
+		DS1963S_TX_FAIL(dev);
+
+	/* XXX: Investigate how many 1s to send later. */
+	for (int i = 0; i < 10; i++)
+		DS1963S_TX_BIT(dev, 1);
+
+	DS1963S_TX_SUCCESS(dev);
+}
+
+int
+ds1963s_dev_sha_command_authenticate_host(struct ds1963s_device *dev)
+{
+	if (ds1963s_dev_authenticate_host(dev) == -1)
+		DS1963S_TX_FAIL(dev);
+
+	/* XXX: Investigate how many 1s to send later. */
+	for (int i = 0; i < 10; i++)
+		DS1963S_TX_BIT(dev, 1);
+
+	DS1963S_TX_SUCCESS(dev);
+}
+
+int
+ds1963s_dev_memory_command_compute_sha(struct ds1963s_device *dev)
+{
+	uint16_t crc16;
+	uint8_t  ctrl;
+
+	dev->TA1 = DS1963S_RX_BYTE(dev);
+	dev->TA2 = DS1963S_RX_BYTE(dev);
+	ctrl     = DS1963S_RX_BYTE(dev);
+
+	crc16    = 0;
+	crc16    = ds1963s_crc16_update_byte(crc16, 0x33);
+	crc16    = ds1963s_crc16_update_byte(crc16, dev->TA1);
+	crc16    = ds1963s_crc16_update_byte(crc16, dev->TA2);
+	crc16    = ds1963s_crc16_update_byte(crc16, ctrl);
+	crc16    = ~crc16;
+	DS1963S_TX_BYTE(dev, crc16 & 0xFF);
+	DS1963S_TX_BYTE(dev, crc16 >> 8);
+
+	switch (ctrl) {
+	case 0x0F:
+		DEBUG_LOG("[ds1963s|SHA] Compute 1st Secret\n");
+		ds1963s_dev_sha_command_compute_first_secret(dev);
+		break;
+	case 0xF0:
+		DEBUG_LOG("[ds1963s|SHA] Compute next Secret\n");
+		ds1963s_dev_sha_command_compute_next_secret(dev);
+		break;
+	case 0x3C:
+		DEBUG_LOG("[ds1963s|SHA] Validate Data Page\n");
+		ds1963s_dev_sha_command_validate_data_page(dev);
+		break;
+	case 0xC3:
+		DEBUG_LOG("[ds1963s|SHA] Sign Data Page\n");
+		return ds1963s_dev_sha_command_sign_data_page(dev);
+	case 0xCC:
+		DEBUG_LOG("[ds1963s|SHA] Compute Challenge\n");
+		ds1963s_dev_sha_command_compute_challenge(dev);
+		break;
+	case 0xAA:
+		DEBUG_LOG("[ds1963s|SHA] Authenticate Host\n");
+		ds1963s_dev_sha_command_authenticate_host(dev);
+		break;
+	default:
+		DEBUG_LOG("[ds1963s|SHA] Unknown command %.2x\n", ctrl);
+		break;
+	}
+
+	return 0;
+}
+
+int
+ds1963s_dev_memory_command_copy_scratchpad(struct ds1963s_device *dev)
+{
+	uint8_t  TA1, TA2, ES;
+	uint16_t addr;
+
+	dev->CHLG = 0;
+	dev->AUTH = 0;
+
+	TA1  = DS1963S_RX_BYTE(dev);
+	TA2  = DS1963S_RX_BYTE(dev);
+	ES   = DS1963S_RX_BYTE(dev);
+	addr = ds1963s_ta_to_address(TA1, TA2);
+
+	if (dev->HIDE == 0 && addr >= 0x200)
+		goto error;
+
+	if (dev->HIDE == 1 && !ds1963s_address_secret(addr))
+		goto error;
+
+	if (TA1 != dev->TA1 || TA2 != dev->TA2 || ES != dev->ES)
+		goto error;
+
+	dev->AA = 1;
+	memcpy(&dev->memory[addr], dev->scratchpad, (ES & 0x1F) + 1);
+
+	hexdump(dev->secret_memory, sizeof dev->secret_memory, 0);
+
+	/* XXX: specs say this happens for 32us.  Investigate how many 1s
+	 * to send later.
+	 */
+	for (int i = 0; i < 8; i++)
+		DS1963S_TX_BIT(dev, 1);
+
+	DS1963S_TX_SUCCESS(dev);
+
+error:
+	DS1963S_TX_FAIL(dev);
+}
+
+int
+ds1963s_dev_memory_command_match_scratchpad(struct ds1963s_device *dev)
+{
+	uint8_t  buf[20];
+	uint16_t crc16;
+
+	dev->CHLG  = 0;
+	dev->MATCH = 0;
+
+	crc16 = 0;
+	crc16 = ds1963s_crc16_update_byte(crc16, 0x3C);
+
+	for (int i = 0; i < 20; i++) {
+		buf[i] = DS1963S_RX_BYTE(dev);
+		crc16  = ds1963s_crc16_update_byte(crc16, buf[i]);
+	}
+
+	/* XXX: datasheet seems to state this is independent of the comparison
+	 * result.  Is this correct?  Need to verify.
+	 */
+	if (dev->AUTH) {
+		dev->AUTH  = 0;
+		dev->MATCH = 1;
+	}
+
+	crc16 = ~crc16;
+	DS1963S_TX_BYTE(dev, crc16 & 0xFF);
+	DS1963S_TX_BYTE(dev, crc16 >> 8);
+
+	if (!memcmp(&dev->scratchpad[8], buf, 20))
+		DS1963S_TX_SUCCESS(dev);
+
+	DS1963S_TX_FAIL(dev);
+}
+
+int
+ds1963s_dev_memory_command_read_authenticated_page(struct ds1963s_device *dev)
+{
+	uint8_t  TA1, TA2;
+	uint8_t  CC[4];
+	uint16_t crc16;
+	uint16_t addr;
+	int      page;
+
+	dev->CHLG = 0;
+	dev->AUTH = 0;
+
+	TA1  = DS1963S_RX_BYTE(dev);
+	TA2  = DS1963S_RX_BYTE(dev);
+	addr = ds1963s_ta_to_address(TA1, TA2);
+	page = ds1963s_address_to_page(addr);
+
+	if (addr >= 0x200)
+		goto error;
+
+	crc16 = 0;
+	crc16 = ds1963s_crc16_update_byte(crc16, 0xA5);
+	crc16 = ds1963s_crc16_update_byte(crc16, TA1);
+	crc16 = ds1963s_crc16_update_byte(crc16, TA2);
+
+	do {
+		DS1963S_TX_BYTE(dev, dev->memory[addr]);
+		crc16 = ds1963s_crc16_update_byte(crc16, dev->memory[addr]);
+	} while (++addr % 32 != 0);
+
+	/* TX the write cycle counter of the page. */
+	PUT_32BIT_LSB(CC, dev->data_wc[page]);
+	for (int j = 0; j < 4; j++) {
+		DS1963S_TX_BYTE(dev, CC[j]);
+		crc16 = ds1963s_crc16_update_byte(crc16, CC[j]);
+	}
+
+	/* TX the write cycle counter of secret for this page. */
+	PUT_32BIT_LSB(CC, dev->secret_wc[page]);
+	for (int j = 0; j < 4; j++) {
+		DS1963S_TX_BYTE(dev, CC[j]);
+		crc16 = ds1963s_crc16_update_byte(crc16, CC[j]);
+	}
+
+	/* TX the crc16 of everything done so far. */
+	crc16 = ~crc16;
+	DS1963S_TX_BYTE(dev, crc16 & 0xFF);
+	DS1963S_TX_BYTE(dev, crc16 >> 8);
+
+	dev->X = 0;
+	/* XXX: FIXME AND WORK OUT THE LOGIC FOR M. */
+	dev->M = 0;
+
+	/* Construct the SHA-1 hash on the scratchpad. */
+	ds1963s_dev_read_auth_page(dev, page);
+
+	/* XXX: Investigate how many 1s to send later. */
+	for (int i = 0; i < 10; i++)
+		DS1963S_TX_BIT(dev, 1);
+
+	DS1963S_TX_SUCCESS(dev);
+
+error:
+	DS1963S_TX_FAIL(dev);
+}
+
+int
+ds1963s_dev_memory_command_read_scratchpad(struct ds1963s_device *dev)
+{
+	uint8_t  offset;
+	uint16_t crc16;
+	int      i;
+
+	DEBUG_LOG("TA1: %x TA2: %x\n", dev->TA1, dev->TA2);
+
+	DS1963S_TX_BYTE(dev, dev->TA1);
+	DS1963S_TX_BYTE(dev, dev->TA2);
+	DS1963S_TX_BYTE(dev, dev->ES);
+
+	offset = dev->TA1 & 0x1F;
+
+	crc16 = 0;
+	crc16 = ds1963s_crc16_update_byte(crc16, 0xAA);
+	crc16 = ds1963s_crc16_update_byte(crc16, dev->TA1);
+	crc16 = ds1963s_crc16_update_byte(crc16, dev->TA2);
+	crc16 = ds1963s_crc16_update_byte(crc16, dev->ES);
+
+	for (i = 4; offset < 32; i++, offset++) {
+		int byte = dev->HIDE ? 0xFF : dev->scratchpad[offset];
+		DS1963S_TX_BYTE(dev, byte);
+		crc16 = ds1963s_crc16_update_byte(crc16, byte);
+	}
+
+	crc16 = ~crc16;
+	DS1963S_TX_BYTE(dev, crc16 & 0xFF);
+	DS1963S_TX_BYTE(dev, crc16 >> 8);
+	DS1963S_TX_END(dev);
+}
+
+int
+ds1963s_dev_memory_command_erase_scratchpad(struct ds1963s_device *dev)
+{
+	dev->CHLG = 0;
+	dev->AUTH = 0;
+	dev->TA1  = DS1963S_RX_BYTE(dev);
+	dev->TA2  = DS1963S_RX_BYTE(dev);
+	dev->ES   = 0x1f;
+
+	memset(dev->scratchpad, 0xFF, sizeof dev->scratchpad);
+	/* Simulate TX 1s until the command is finished.
+	 *
+	 * XXX: specs say this happens for 32us.  Investigate how many 1s
+	 * to send later.
+	 */
+	for (int i = 0; i < 10; i++)
+		DS1963S_TX_BIT(dev, 1);
+
+	dev->HIDE = 0;
+
+	DS1963S_TX_SUCCESS(dev);
+}
+
+int
+ds1963s_dev_memory_command_read_memory(struct ds1963s_device *dev)
+{
+	uint8_t  TA1, TA2;
+	uint16_t addr;
+	int page;
+
+	dev->CHLG = 0;
+	dev->AUTH = 0;
+
+	TA1  = DS1963S_RX_BYTE(dev);
+	TA2  = DS1963S_RX_BYTE(dev);
+	addr = ds1963s_ta_to_address(TA1, TA2);
+
+	while (addr < 0x2B0) {
+		ds1963s_address_to_ta(addr, &dev->TA1, &dev->TA2);
+
+		page = ds1963s_address_to_page(addr);
+		if (page == 16 || page == 17) {
+			DS1963S_TX_BYTE(dev, 0xFF);
+		} else {
+			DS1963S_TX_BYTE(dev, dev->memory[addr]);
+		}
+
+		/* DS1963S does not increment addr past 0x2AF. */
+		if (addr == 0x2AF) break;
+		addr += 1;
+	}
+
+	DS1963S_TX_END(dev);
+}
+
+int
+ds1963s_dev_memory_function(struct ds1963s_device *dev)
+{
+	int byte;
+
+	assert(dev != NULL);
+
+	byte = DS1963S_RX_BYTE(dev);
+
+	switch (byte) {
+	case 0x0F:
+		DEBUG_LOG("[ds1963s|MEMORY] Write Scratchpad\n");
+		ds1963s_dev_memory_command_write_scratchpad(dev);
+		break;
+	case 0x33:
+		DEBUG_LOG("[ds1963s|MEMORY] Compute SHA\n");
+		ds1963s_dev_memory_command_compute_sha(dev);
+		break;
+	case 0x3C:
+		DEBUG_LOG("[ds1963s|MEMORY] Match Scratchpad\n");
+		ds1963s_dev_memory_command_match_scratchpad(dev);
+		break;
+	case 0x55:
+		DEBUG_LOG("[ds1963s|MEMORY] Copy Scratchpad\n");
+		ds1963s_dev_memory_command_copy_scratchpad(dev);
+		break;
+	case 0xA5:
+		DEBUG_LOG("[ds1963s|MEMORY] Read Authenticated Page\n");
+		ds1963s_dev_memory_command_read_authenticated_page(dev);
+		break;
+	case 0xAA:
+		DEBUG_LOG("[ds1963s|MEMORY] Read Scratchpad\n");
+		ds1963s_dev_memory_command_read_scratchpad(dev);
+		break;
+	case 0xC3:
+		DEBUG_LOG("[ds1963s|MEMORY] Erase Scratchpad\n");
+		ds1963s_dev_memory_command_erase_scratchpad(dev);
+		break;
+	case 0xF0:
+		DEBUG_LOG("[ds1963s|MEMORY] Read Memory\n");
+		ds1963s_dev_memory_command_read_memory(dev);
+		break;
+	default:
+		DEBUG_LOG("[ds1963s|MEMORY] Unknown command %.2x\n", byte);
+		break;
+	}
+
+	return 0;
+}
+
+int ds1963s_dev_power_on(struct ds1963s_device *dev)
+{
+        assert(dev != NULL);
+
+	while (dev->state != DS1963S_STATE_TERMINATED) {
+		switch(dev->state) {
+		case DS1963S_STATE_INITIAL:
+			DEBUG_LOG("[ds1963s|INITIAL] power on\n");
+			dev->state = DS1963S_STATE_RESET_WAIT;
+			break;
+		case DS1963S_STATE_RESET_WAIT:
+			DEBUG_LOG("[ds1963s|RESET_WAIT] waiting on reset\n");
+			/* We ignore things until we see a reset pulse. */
+			while (one_wire_bus_member_rx_bit(&dev->bus_slave) != -1)
+				break;
+
+			DEBUG_LOG("[ds1963s|RESET_WAIT] Received reset pulse...\n");
+			dev->state = DS1963S_STATE_RESET;
+			break;
+		case DS1963S_STATE_RESET:
+			DEBUG_LOG("[ds1963s|RESET] Waiting for ROM function...\n");
+
+#if 0			/* XXX: hack, we don't hot-add to the topology anyway,
+			 * so for now we don't need this.
+			 */
+			ds1963s_dev_rx_bit(dev);
+			DEBUG_LOG("[ds1963s|RESET] Sending presence pulse\n");
+			ds1963s_dev_tx_bit(dev, 1);
+#endif
+			dev->state = DS1963S_STATE_ROM_FUNCTION;
+			break;
+		case DS1963S_STATE_ROM_FUNCTION:
+			ds1963s_dev_rom_function(dev);
+			break;
+		case DS1963S_STATE_MEMORY_FUNCTION:
+			ds1963s_dev_memory_function(dev);
+			break;
+		}
+	}
+
+	return 0;
+}

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ds1963s-device.h
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ds1963s-device.h
@@ -1,0 +1,98 @@
+/* ds1963s-device.h
+ *
+ * A software implementation of the DS1963S iButton.
+ *
+ * Dedicated to Yuzuyu Arielle Huizer.
+ *
+ * Copyright (C) 2016-2019  Ronald Huizer <rhuizer@hexpedition.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef DS1963S_DEVICE_H
+#define DS1963S_DEVICE_H
+
+#include "1-wire-bus.h"
+
+#define DS1963S_DEVICE_FAMILY		0x18
+
+#define DS1963S_STATE_TERMINATED	-1
+#define DS1963S_STATE_INITIAL		0
+#define DS1963S_STATE_RESET_WAIT	1
+#define DS1963S_STATE_RESET		2
+#define DS1963S_STATE_ROM_FUNCTION	3
+#define DS1963S_STATE_MEMORY_FUNCTION	4
+
+struct ds1963s_device
+{
+	uint8_t		family;
+	uint8_t		serial[6];
+
+	union {
+		uint8_t		memory[1024];
+
+		struct {
+			uint8_t		data_memory[512];
+			uint8_t		secret_memory[64];
+			uint8_t		scratchpad[32];
+			uint32_t	data_wc[8];
+			uint32_t	secret_wc[8];
+			uint32_t	prng_counter;
+		};
+	};
+
+	uint8_t		TA1;
+	uint8_t		TA2;
+	uint8_t		ES;
+
+	uint8_t		M:1;
+	uint8_t		X:1;
+	uint8_t		HIDE:1;
+	uint8_t		CHLG:1;
+	uint8_t		AUTH:1;
+	uint8_t		MATCH:1;
+	uint8_t		OD:1;
+	uint8_t		PF:1;
+	uint8_t		RC:1;
+	uint8_t		AA:1;
+
+	int		state;
+
+	/* The 1-wire bus the ds1963s is connected to as a slave. */
+	struct one_wire_bus_member bus_slave;
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void     ds1963s_dev_init(struct ds1963s_device *dev);
+void     ds1963s_dev_destroy(struct ds1963s_device *dev);
+uint64_t ds1963s_rom_code_get(struct ds1963s_device *dev);
+
+int   ds1963s_dev_pf_get(struct ds1963s_device *dev);
+void  ds1963s_dev_pf_set(struct ds1963s_device *dev, int pf);
+
+void ds1963s_dev_connect_bus(struct ds1963s_device *ds1963s, struct one_wire_bus *bus);
+int  ds1963s_dev_power_on(struct ds1963s_device *ds1963s);
+
+void ds1963s_dev_erase_scratchpad(struct ds1963s_device *ds1963s, int address);
+void ds1963s_dev_read_auth_page(struct ds1963s_device *ds1963s, int page);
+int  ds1963s_dev_sign_data_page(struct ds1963s_device *dev);
+int  ds1963s_dev_validate_data_page(struct ds1963s_device *dev);
+
+#ifdef __cplusplus
+};
+#endif
+
+#endif

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ds1963s-emulator-yaml.c
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ds1963s-emulator-yaml.c
@@ -1,0 +1,689 @@
+/* ds1963s-emulator-yaml.c
+ *
+ * Parse a yaml configuration defining the ds1963s ibutton to emulate.
+ *
+ * Dedicated to Yuzuyu Arielle Huizer.
+ *
+ * Not a fan of libyaml in C, this code is a horribly convoluted state machine.
+ * Either I've gotten the use wrong, or the design of libyaml is bad.  Instead
+ * of saving time and work it wasted and created it, which is the opposite of
+ * what a good library is supposed to do.
+ *
+ * Copyright (C) 2016-2019  Ronald Huizer <rhuizer@hexpedition.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include <ctype.h>
+#include <yaml.h>
+#include "ds1963s-common.h"
+#include "ds1963s-device.h"
+
+#define STATE_INIT		0
+#define STATE_DOCUMENT		1
+#define STATE_GLOBAL_MAP	2
+#define STATE_KEY		3
+#define STATE_FAMILY		4
+#define STATE_SERIAL		5
+#define STATE_CRC8		6
+#define STATE_PRNG_COUNTER	7
+#define STATE_WRITE_CYCLE_MAP	8
+#define STATE_WRITE_CYCLE_KEY	9
+#define STATE_WRITE_CYCLE_VALUE	10
+#define STATE_NVRAM_MAP		11
+#define STATE_NVRAM_KEY		12
+#define STATE_NVRAM_VALUE	13
+#define STATE_SECRET_MAP	14
+#define STATE_SECRET_KEY	15
+#define STATE_SECRET_VALUE	16
+#define STATE_DOCUMENT_END	17
+#define STATE_STREAM_END	18
+
+#define SEEN_FAMILY		1
+#define SEEN_SERIAL		2
+#define SEEN_CRC8		4
+#define SEEN_PRNG_COUNTER	8
+#define SEEN_SECRET		16
+#define SEEN_WRITE_CYCLE	32
+#define SEEN_NVRAM		64
+#define SEEN_ALL		127
+
+struct parser_context {
+	yaml_parser_t	parser;
+	yaml_event_t	event;
+	int		state;
+	uint16_t	key_seen;
+
+	uint8_t		family;
+	uint8_t		serial[6];
+
+	uint32_t	prng_counter;
+
+	uint32_t *	wcp;
+	uint16_t	wc_seen;
+	uint32_t	data_wc[8];
+	uint32_t	secret_wc[8];
+
+	uint8_t *	nvp;
+	uint16_t	nvram_seen;
+	uint8_t		nvram[512];
+
+	uint8_t *	sp;
+	uint8_t		secret_seen;
+	uint8_t		secret[64];
+
+};
+
+static void
+__parser_init(struct parser_context *ctx, FILE *fp)
+{
+	memset(ctx, 0, sizeof *ctx);
+	yaml_parser_initialize(&ctx->parser);
+	yaml_parser_set_input_file(&ctx->parser, fp);
+	ctx->state    = STATE_INIT;
+}
+
+static void
+__parser_error(struct parser_context *ctx)
+{
+	assert(ctx != NULL);
+
+        fprintf(stderr, "Parse error %d: %s\n", ctx->parser.error,
+	                                        ctx->parser.problem);
+        yaml_parser_delete(&ctx->parser);
+        exit(EXIT_FAILURE);
+}
+
+static void
+__parser_parse(struct parser_context *ctx)
+{
+	if (yaml_parser_parse(&ctx->parser, &ctx->event) == -1)
+		__parser_error(ctx);
+}
+
+static void
+__yaml_key_error(yaml_parser_t *parser, const char *key)
+{
+	fprintf(stderr, "Parse error: unknown key `%s'.\n", key);
+	yaml_parser_delete(parser);
+	exit(EXIT_FAILURE);
+}
+
+static unsigned int
+__parse_int(yaml_parser_t *parser, const char *s)
+{
+	char *endptr;
+	int ret;
+
+	if (*s == 0) {
+		fprintf(stderr, "Parse error: empty value.\n");
+		yaml_parser_delete(parser);
+		exit(EXIT_FAILURE);
+	}
+
+	ret = strtoul(s, &endptr, 16);
+
+	if (*endptr != 0) {
+		fprintf(stderr, "Parse error: invalid integer: `%s'\n", endptr);
+		yaml_parser_delete(parser);
+		exit(EXIT_FAILURE);
+	}
+
+	return ret;
+}
+
+static void
+__is_hex_string(yaml_parser_t *parser, const char *s)
+{
+	for (; *s != 0; s++) {
+		if (!isxdigit(*s)) {
+			fprintf(stderr, "Parse error: invalid hex string: `%s'\n", s);
+			yaml_parser_delete(parser);
+			exit(EXIT_FAILURE);
+		}
+	}
+}
+
+static void
+__is_length(yaml_parser_t *parser, const char *s, size_t size)
+{
+	if (strlen(s) != size) {
+		fprintf(stderr, "Parse error: invalid length: `%s'. "
+		                "Expected %zu.\n", s, size);
+		yaml_parser_delete(parser);
+		exit(EXIT_FAILURE);
+	}
+}
+
+static void
+__handle_init(struct parser_context *ctx)
+{
+	assert(ctx != NULL);
+	assert(ctx->state == STATE_INIT);
+
+	if (ctx->event.type != YAML_STREAM_START_EVENT) {
+		fprintf(stderr, "Expected start event.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	ctx->state = STATE_DOCUMENT;
+}
+
+static void
+__handle_stream_end(struct parser_context *ctx)
+{
+	assert(ctx != NULL);
+	assert(ctx->state == STATE_STREAM_END);
+
+	if (ctx->event.type != YAML_STREAM_END_EVENT) {
+		fprintf(stderr, "Expected stream end event.\n");
+		exit(EXIT_FAILURE);
+	}
+}
+
+static void
+__handle_global_map(struct parser_context *ctx)
+{
+	assert(ctx != NULL);
+	assert(ctx->state == STATE_GLOBAL_MAP);
+
+	if (ctx->event.type != YAML_MAPPING_START_EVENT) {
+		fprintf(stderr, "Expected map start event.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	ctx->state = STATE_KEY;
+}
+
+static void
+__handle_global_key(struct parser_context *ctx)
+{
+	const char *str;
+
+	if (ctx->event.type == YAML_MAPPING_END_EVENT) {
+		if (ctx->key_seen != SEEN_ALL) {
+			fprintf(stderr, "Warning: not all keys have been "
+			                "defined.\n");
+		}
+
+		ctx->state = STATE_DOCUMENT_END;
+		return;
+	}
+
+	if (ctx->event.type != YAML_SCALAR_EVENT) {
+		fprintf(stderr, "Expected scalar event.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	str = (char *)ctx->event.data.scalar.value;
+
+	if (strcmp(str, "family") == 0)
+		ctx->state = STATE_FAMILY;
+	else if (strcmp(str, "serial") == 0)
+		ctx->state = STATE_SERIAL;
+	else if (strcmp(str, "crc8") == 0)
+		ctx->state = STATE_CRC8;
+	else if (strcmp(str, "write_cycle_counters") == 0)
+		ctx->state = STATE_WRITE_CYCLE_MAP;
+	else if (strcmp(str, "nvram") == 0)
+		ctx->state = STATE_NVRAM_MAP;
+	else if (strcmp(str, "prng_counter") == 0)
+		ctx->state = STATE_PRNG_COUNTER;
+	else if (strcmp(str, "secrets") == 0)
+		ctx->state = STATE_SECRET_MAP;
+	else
+		__yaml_key_error(&ctx->parser, str);
+}
+
+static void
+__handle_family(struct parser_context *ctx)
+{
+	const char *str;
+
+	if (ctx->event.type != YAML_SCALAR_EVENT) {
+		fprintf(stderr, "Expected scalar event.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	str = (char *)ctx->event.data.scalar.value;
+
+	ctx->family    = __parse_int(&ctx->parser, str);
+	ctx->state     = STATE_KEY;
+	ctx->key_seen |= SEEN_FAMILY;
+}
+
+static void
+__handle_serial(struct parser_context *ctx)
+{
+	const char *str;
+
+	if (ctx->event.type != YAML_SCALAR_EVENT) {
+		fprintf(stderr, "Expected scalar event.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	str = (char *)ctx->event.data.scalar.value;
+
+	__is_hex_string(&ctx->parser, str);
+	__is_length(&ctx->parser, str, sizeof(ctx->serial) * 2);
+	hex_decode(ctx->serial, str, sizeof ctx->serial);
+	ctx->state     = STATE_KEY;
+	ctx->key_seen |= SEEN_SERIAL;
+}
+
+static void
+__handle_prng(struct parser_context *ctx)
+{
+	const char *str;
+
+	if (ctx->event.type != YAML_SCALAR_EVENT) {
+		fprintf(stderr, "Expected scalar event.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	str = (char *)ctx->event.data.scalar.value;
+
+	ctx->prng_counter = __parse_int(&ctx->parser, str);
+	ctx->state        = STATE_KEY;
+	ctx->key_seen    |= SEEN_PRNG_COUNTER;
+}
+
+static void
+__handle_document(struct parser_context *ctx)
+{
+	assert(ctx != NULL);
+	assert(ctx->state == STATE_DOCUMENT);
+
+	if (ctx->event.type != YAML_DOCUMENT_START_EVENT) {
+		fprintf(stderr, "Expected start event.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	ctx->state = STATE_GLOBAL_MAP;
+}
+
+static void
+__handle_document_end(struct parser_context *ctx)
+{
+	assert(ctx != NULL);
+	assert(ctx->state == STATE_DOCUMENT_END);
+
+	if (ctx->event.type != YAML_DOCUMENT_END_EVENT) {
+		fprintf(stderr, "Expected document end event.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	ctx->state = STATE_STREAM_END;
+}
+
+static void
+__handle_write_cycle_map(struct parser_context *ctx)
+{
+	assert(ctx != NULL);
+	assert(ctx->state == STATE_WRITE_CYCLE_MAP);
+
+	if (ctx->event.type != YAML_MAPPING_START_EVENT) {
+		fprintf(stderr, "Expected start event.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	ctx->state = STATE_WRITE_CYCLE_KEY;
+}
+
+static void
+__handle_write_cycle_key(struct parser_context *ctx)
+{
+	unsigned int i;
+	const char *s;
+	char *endptr;
+
+	assert(ctx != NULL);
+	assert(ctx->state == STATE_WRITE_CYCLE_KEY);
+
+	if (ctx->event.type == YAML_MAPPING_END_EVENT) {
+		if (ctx->wc_seen != 0xFFFF) {
+			fprintf(stderr, "Warning: not all write cycle "
+					"counters have been defined.\n");
+		}
+
+		ctx->state = STATE_KEY;
+		return;
+	}
+
+	if (ctx->event.type != YAML_SCALAR_EVENT) {
+		fprintf(stderr, "Expected scalar event.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	s = (char *)ctx->event.data.scalar.value;
+
+	if (!strncmp(s, "data_page_", 10) && s[10] != 0) {
+		i = strtoul(&s[10], &endptr, 10);
+		if (*endptr != 0 || i < 8 || i > 15)
+			goto error;
+
+		if (ctx->wc_seen & (i << i)) {
+			fprintf(stderr, "Warning: redefined write cycle "
+					"counter `%s'.\n", s);
+		}
+
+		ctx->wc_seen |= 1 << i;
+		ctx->wcp      = &ctx->data_wc[i - 8];
+		ctx->state    = STATE_WRITE_CYCLE_VALUE;
+		return;
+	}
+
+	if (!strncmp(s, "secret_", 7) && s[7] != 0) {
+		i = strtoul(&s[7], &endptr, 10);
+		if (*endptr != 0 || i > 7)
+			goto error;
+
+		ctx->wc_seen |= 1 << i;
+		ctx->wcp      = &ctx->secret_wc[i];
+		ctx->state    = STATE_WRITE_CYCLE_VALUE;
+		return;
+	}
+
+error:
+	fprintf(stderr, "Parse error: unknown write-cycle key `%s'.\n", s);
+	yaml_parser_delete(&ctx->parser);
+	exit(EXIT_FAILURE);
+}
+
+static void
+__handle_write_cycle_value(struct parser_context *ctx)
+{
+	const char *str;
+
+	assert(ctx != NULL);
+	assert(ctx->state == STATE_WRITE_CYCLE_VALUE);
+
+	if (ctx->event.type != YAML_SCALAR_EVENT) {
+		fprintf(stderr, "Expected scalar event.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	str       = (char *)ctx->event.data.scalar.value;
+	*ctx->wcp = __parse_int(&ctx->parser, str);
+
+	ctx->state = STATE_WRITE_CYCLE_KEY;
+}
+
+static void
+__handle_nvram_map(struct parser_context *ctx)
+{
+	assert(ctx != NULL);
+	assert(ctx->state == STATE_NVRAM_MAP);
+
+	if (ctx->event.type != YAML_MAPPING_START_EVENT) {
+		fprintf(stderr, "Expected start event.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	ctx->state = STATE_NVRAM_KEY;
+}
+
+static void
+__handle_nvram_key(struct parser_context *ctx)
+{
+	unsigned int i;
+	const char *s;
+	char *endptr;
+
+	assert(ctx != NULL);
+	assert(ctx->state == STATE_NVRAM_KEY);
+
+	if (ctx->event.type == YAML_MAPPING_END_EVENT) {
+		if (ctx->nvram_seen != 0xFFFF) {
+			fprintf(stderr, "Warning: not all nvram pages "
+					"have been defined.\n");
+		}
+
+		ctx->state = STATE_KEY;
+		return;
+	}
+
+	if (ctx->event.type != YAML_SCALAR_EVENT) {
+		fprintf(stderr, "Expected scalar event.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	s = (char *)ctx->event.data.scalar.value;
+
+	if (!strncmp(s, "page_", 5) && s[5] != 0) {
+		i = strtoul(&s[5], &endptr, 10);
+		if (*endptr != 0 || i > 15)
+			goto error;
+
+		if (ctx->nvram_seen & (i << i)) {
+			fprintf(stderr, "Warning: redefined nvram "
+					"page `%s'.\n", s);
+		}
+
+		ctx->nvram_seen |= 1 << i;
+		ctx->nvp         = &ctx->nvram[i * 32];
+		ctx->state       = STATE_NVRAM_VALUE;
+		return;
+	}
+
+error:
+	fprintf(stderr, "Parse error: unknown nvram key `%s'.\n", s);
+	yaml_parser_delete(&ctx->parser);
+	exit(EXIT_FAILURE);
+}
+
+static void
+__handle_nvram_value(struct parser_context *ctx)
+{
+	const char *str;
+
+	assert(ctx != NULL);
+	assert(ctx->state == STATE_NVRAM_VALUE);
+
+	if (ctx->event.type != YAML_SCALAR_EVENT) {
+		fprintf(stderr, "Expected scalar event.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	str = (char *)ctx->event.data.scalar.value;
+	__is_hex_string(&ctx->parser, str);
+	__is_length(&ctx->parser, str, 64);
+	hex_decode(ctx->nvp, str, 32);
+	ctx->state = STATE_NVRAM_KEY;
+}
+
+static void
+__handle_secret_map(struct parser_context *ctx)
+{
+	assert(ctx != NULL);
+	assert(ctx->state == STATE_SECRET_MAP);
+
+	if (ctx->event.type != YAML_MAPPING_START_EVENT) {
+		fprintf(stderr, "Expected start event.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	ctx->state = STATE_SECRET_KEY;
+}
+
+static void
+__handle_secret_key(struct parser_context *ctx)
+{
+	unsigned int i;
+	const char *s;
+	char *endptr;
+
+	assert(ctx != NULL);
+	assert(ctx->state == STATE_SECRET_KEY);
+
+	if (ctx->event.type == YAML_MAPPING_END_EVENT) {
+		if (ctx->secret_seen != 0xFF) {
+			fprintf(stderr, "Warning: not all secrets "
+					"have been defined.\n");
+		}
+
+		ctx->state = STATE_KEY;
+		return;
+	}
+
+	if (ctx->event.type != YAML_SCALAR_EVENT) {
+		fprintf(stderr, "Expected scalar event.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	s = (char *)ctx->event.data.scalar.value;
+
+	if (!strncmp(s, "secret_", 7) && s[7] != 0) {
+		i = strtoul(&s[7], &endptr, 10);
+		if (*endptr != 0 || i > 7)
+			goto error;
+
+		if (ctx->secret_seen & (i << i)) {
+			fprintf(stderr, "Warning: redefined secret "
+					"`%s'.\n", s);
+		}
+
+		ctx->secret_seen |= 1 << i;
+		ctx->sp           = &ctx->secret[i * 8];
+		ctx->state        = STATE_SECRET_VALUE;
+		return;
+	}
+
+error:
+	fprintf(stderr, "Parse error: unknown nvram key `%s'.\n", s);
+	yaml_parser_delete(&ctx->parser);
+	exit(EXIT_FAILURE);
+}
+
+static void
+__handle_secret_value(struct parser_context *ctx)
+{
+	const char *str;
+
+	assert(ctx != NULL);
+	assert(ctx->state == STATE_SECRET_VALUE);
+
+	if (ctx->event.type != YAML_SCALAR_EVENT) {
+		fprintf(stderr, "Expected scalar event.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	str = (char *)ctx->event.data.scalar.value;
+	__is_hex_string(&ctx->parser, str);
+	__is_length(&ctx->parser, str, 16);
+	hex_decode(ctx->sp, str, 8);
+	ctx->state = STATE_SECRET_KEY;
+}
+
+int
+ds1963s_emulator_yaml_load(struct ds1963s_device *dev, const char *pathname)
+{
+	struct parser_context ctx;
+	FILE *fp;
+
+	if ( (fp = fopen(pathname, "r")) == NULL) {
+		perror("fopen()");
+		exit(EXIT_FAILURE);
+	}
+
+	__parser_init(&ctx, fp);
+
+	do {
+		__parser_parse(&ctx);
+
+		switch (ctx.state) {
+		case STATE_INIT:
+			__handle_init(&ctx);
+			break;
+		case STATE_DOCUMENT:
+			__handle_document(&ctx);
+			break;
+		case STATE_GLOBAL_MAP:
+			__handle_global_map(&ctx);
+			break;
+		case STATE_KEY:
+			__handle_global_key(&ctx);
+			break;
+		case STATE_FAMILY:
+			__handle_family(&ctx);
+			break;
+		case STATE_SERIAL:
+			__handle_serial(&ctx);
+			break;
+		case STATE_CRC8:
+			/* XXX: ignore for now; we calculate it. */
+			ctx.state     = STATE_KEY;
+			ctx.key_seen |= SEEN_CRC8;
+			break;
+		case STATE_PRNG_COUNTER:
+			__handle_prng(&ctx);
+			break;
+		case STATE_WRITE_CYCLE_MAP:
+			__handle_write_cycle_map(&ctx);
+			ctx.key_seen |= SEEN_WRITE_CYCLE;
+			break;
+		case STATE_WRITE_CYCLE_KEY:
+			__handle_write_cycle_key(&ctx);
+			break;
+		case STATE_WRITE_CYCLE_VALUE:
+			__handle_write_cycle_value(&ctx);
+			break;
+		case STATE_NVRAM_MAP:
+			__handle_nvram_map(&ctx);
+			ctx.key_seen |= SEEN_NVRAM;
+			break;
+		case STATE_NVRAM_KEY:
+			__handle_nvram_key(&ctx);
+			break;
+		case STATE_NVRAM_VALUE:
+			__handle_nvram_value(&ctx);
+			break;
+		case STATE_SECRET_MAP:
+			__handle_secret_map(&ctx);
+			ctx.key_seen |= SEEN_SECRET;
+			break;
+		case STATE_SECRET_KEY:
+			__handle_secret_key(&ctx);
+			break;
+		case STATE_SECRET_VALUE:
+			__handle_secret_value(&ctx);
+			break;
+		case STATE_DOCUMENT_END:
+			__handle_document_end(&ctx);
+			break;
+		case STATE_STREAM_END:
+			__handle_stream_end(&ctx);
+			break;
+		default:
+			fprintf(stderr, "unknown state: %d\n", ctx.state);
+			abort();
+		}
+	} while (ctx.event.type != YAML_STREAM_END_EVENT);
+
+	fclose(fp);
+
+	dev->family         = ctx.family;
+	dev->prng_counter   = ctx.prng_counter;
+	memcpy(dev->data_wc,       ctx.data_wc,   sizeof dev->data_wc);
+	memcpy(dev->secret_wc,     ctx.secret_wc, sizeof dev->secret_wc);
+	memcpy(dev->data_memory,   ctx.nvram,     sizeof dev->data_memory);
+	memcpy(dev->secret_memory, ctx.secret,    sizeof dev->secret_memory);
+
+	/* Serial is a special case, as it is stored LSB first.  For
+	 * presentation it has been reversed, so do this here too.
+	 */
+	for (int i = 0; i < sizeof dev->serial; i++)
+		dev->serial[i] = ctx.serial[sizeof(ctx.serial) - 1 - i];
+
+	return 0;
+}

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ds1963s-emulator-yaml.h
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ds1963s-emulator-yaml.h
@@ -1,0 +1,37 @@
+/* ds1963s-emulator-yaml.h
+ *
+ * Parse a yaml configuration defining the ds1963s ibutton to emulate.
+ *
+ * Dedicated to Yuzuyu Arielle Huizer.
+ *
+ * Copyright (C) 2016-2019  Ronald Huizer <rhuizer@hexpedition.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef DS1963S_EMULATOR_YAML
+#define DS1963S_EMULATOR_YAML
+
+#include "ds1963s-device.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int ds1963s_emulator_yaml_load(struct ds1963s_device *dev, const char *pathname);
+
+#ifdef __cplusplus
+};
+#endif
+
+#endif

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ds1963s-emulator.c
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ds1963s-emulator.c
@@ -1,0 +1,136 @@
+/* ds1963s-emulator.c
+ *
+ * A software emulator for a DS2048B and DS1963S 1-wire topology that can
+ * connect to a serial device over a unix domain socket.
+ *
+ * Dedicated to Yuzuyu Arielle Huizer.
+ *
+ * Copyright (C) 2016-2019  Ronald Huizer <rhuizer@hexpedition.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <getopt.h>
+#include "ds1963s-device.h"
+#include "ds2480b-device.h"
+#include "transport-factory.h"
+#include "transport-pty.h"
+#include "transport-unix.h"
+#ifdef HAVE_LIBYAML
+#include "ds1963s-emulator-yaml.h"
+#endif
+
+#define PROGNAME                "ds1963s-emulator"
+#define UNIX_SOCKET_PATH	"/tmp/.ds2480-serial"
+
+static const struct option options[] = {
+	{ "config",             1,      NULL,   'c' },
+	{ "device",             1,      NULL,   'd' },
+	{ "help",               0,      NULL,   'h' },
+	{ "transport",		1,	NULL,	't' }
+};
+
+const char optstr[] = "c:d:ht:";
+
+void usage(const char *progname)
+{
+	fprintf(stderr, "Use as: %s [OPTION]\n", progname ?: PROGNAME);
+	fprintf(stderr, "   -c --config=pathname  the configuration file to "
+	                "use.\n");
+	fprintf(stderr, "   -d --device=pathname  the unix socket to use as "
+	                "serial device.\n");
+	fprintf(stderr, "   -h --help             display the help menu.\n");
+	fprintf(stderr, "   -t --transport        transport to use.\n");
+}
+
+int main(int argc, char **argv)
+{
+	struct ds1963s_device ds1963s;
+	struct ds2480b_device ds2480b;
+	struct transport *serial;
+	struct one_wire_bus bus;
+	const char *config_name;
+	const char *device_name;
+	const char *transport;
+	int i, o;
+
+	config_name = NULL;
+	device_name = UNIX_SOCKET_PATH;
+	transport   = "unix";
+	while ( (o = getopt_long(argc, argv, optstr, options, &i)) != -1) {
+		switch (o) {
+		case 'c':
+			config_name = optarg;
+			break;
+		case 'd':
+			device_name = optarg;
+			break;
+		case 'h':
+			usage(argv[0]);
+			exit(EXIT_SUCCESS);
+		case 't':
+			transport = optarg;
+			break;
+		}
+	}
+
+	one_wire_bus_init(&bus);
+	ds1963s_dev_init(&ds1963s);
+	ds2480b_dev_init(&ds2480b);
+
+	if (config_name != NULL) {
+#ifdef HAVE_LIBYAML
+		ds1963s_emulator_yaml_load(&ds1963s, config_name);
+#else
+		fprintf(stderr, "%s has been built without libyaml support.\n"
+		                "libyaml is necessary for loading "
+		                "configurations.\n", argv[0] ?: PROGNAME);
+		exit(EXIT_FAILURE);
+#endif
+	}
+
+	if ( (serial = transport_factory_new_by_name(transport)) == NULL) {
+		perror("transport_factory_new()");
+		exit(EXIT_FAILURE);
+	}
+
+	if (serial->type == TRANSPORT_UNIX) {
+		if (transport_unix_connect(serial, device_name) != 0) {
+			perror("transport_unix_connect()");
+			exit(EXIT_FAILURE);
+		}
+	} else if (serial->type == TRANSPORT_PTY) {
+		struct transport_pty_data *data;
+
+		data = (struct transport_pty_data *)serial->private_data;
+		printf("Please use device %s\n", data->pathname_slave);
+	}
+
+	/* Connect the ds2480b to the host serial port and the 1-wire bus. */
+	ds2480b_dev_connect_serial(&ds2480b, serial);
+
+	if (ds2480b_dev_bus_connect(&ds2480b, &bus) == -1) {
+		fprintf(stderr, "Could not connect DS2480 to 1-wire bus.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	/* Connect the ds1963s to the 1-wire bus. */
+	ds1963s_dev_connect_bus(&ds1963s, &bus);
+
+	/* Run the whole emulated bus topology. */
+	one_wire_bus_run(&bus);
+
+	transport_destroy(serial);
+}

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ds1963s-error.c
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ds1963s-error.c
@@ -1,0 +1,67 @@
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include "ds1963s-error.h"
+
+static char *__errors[] = {
+	"Success",
+	"Failed to open serial port",
+	"DS2480B adapter not found",
+	"Invalid address.  Valid addresses are 0..704",
+	"Failed to set serial control bits",
+	"Failed to change 1-Wire level",
+	"DS1963S ibutton not found",
+	"Invalid secret number",
+	"Invalid secret length",
+	"Invalid data length",
+	"Access to device failed",
+	"Failed to transmit data block",
+	"Failed to erase scratchpad",
+	"Failed to read scratchpad",
+	"Data integrity error",
+	"Failed to copy scratchpad",
+	"Invalid page number.  Valid numbers are 0..21",
+	"SHA function failed",
+	"Copy Scratchpad failed",
+	"Copy secret failed",
+	"Read Scratchpad failed",
+	"Match Scratchpad failed"
+};
+
+static size_t errnum = sizeof(__errors) / sizeof(char *);
+
+void
+ds1963s_perror(int errno, const char *fmt, ...)
+{
+	va_list ap;
+
+	va_start(ap, fmt);
+	ds1963s_vperror(errno, fmt, ap);
+	va_end(ap);
+}
+
+void
+ds1963s_vperror(int errno, const char *fmt, va_list ap)
+{
+	char buf[1024];
+	char *msg;
+
+	if (fmt && vasprintf(&msg, fmt, ap) == -1) {
+		if (vsnprintf(buf, sizeof buf, fmt, ap) < 0)
+			return;
+
+		msg = buf;
+	}
+
+	if (fmt)
+		fprintf(stderr, "%s: ", msg);
+
+	if (errno < 0 || errno >= errnum)
+		fprintf(stderr, "Unknown error number.\n");
+	else
+		fprintf(stderr, "%s.\n", __errors[errno]);
+
+
+	if (fmt && msg != buf)
+		free(msg);
+}

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ds1963s-error.h
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ds1963s-error.h
@@ -1,0 +1,40 @@
+#ifndef DS1963S_ERROR_H
+#define DS1963S_ERROR_H
+
+#include <stdarg.h>
+
+#define DS1963S_ERROR_SUCCESS		0
+#define DS1963S_ERROR_OPENCOM		1
+#define DS1963S_ERROR_NO_DS2480		2
+#define DS1963S_ERROR_INVALID_ADDRESS	3
+#define DS1963S_ERROR_SET_CONTROL_BITS	4
+#define DS1963S_ERROR_SET_LEVEL		5
+#define DS1963S_ERROR_NOT_FOUND		6
+#define DS1963S_ERROR_SECRET_NUM	7	/* Invalid secret.          */
+#define DS1963S_ERROR_SECRET_LEN	8	/* Invalid secret length.   */
+#define DS1963S_ERROR_DATA_LEN		9	/* Invalid data length.     */
+#define DS1963S_ERROR_ACCESS		10	/* Access to device failed. */
+#define DS1963S_ERROR_TX_BLOCK		11	/* Failed to TX data block. */
+#define DS1963S_ERROR_SP_ERASE		12	/* Failed to erase scratch. */
+#define DS1963S_ERROR_SP_READ		13	/* Failed to read scratch.  */
+#define DS1963S_ERROR_INTEGRITY		14	/* Data integrity error.    */
+#define DS1963S_ERROR_SP_COPY		15	/* Failed to copy scratch.  */
+#define DS1963S_ERROR_INVALID_PAGE	16	/* Invalid page number.     */
+#define DS1963S_ERROR_SHA_FUNCTION	17	/* SHA function failed.     */
+#define DS1963S_ERROR_COPY_SCRATCHPAD	18	/* Copy Scratchpad failed.  */
+#define DS1963S_ERROR_COPY_SECRET	19	/* Copy secret failed.      */
+#define DS1963S_ERROR_READ_SCRATCHPAD	20	/* Read Scratchpad failed.  */
+#define DS1963S_ERROR_MATCH_SCRATCHPAD	21	/* Match Scratchpad failed. */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void ds1963s_perror(int errno, const char *fmt, ...);
+void ds1963s_vperror(int errno, const char *fmt, va_list ap);
+
+#ifdef __cplusplus
+};
+#endif
+
+#endif

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ds1963s-shell.c
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ds1963s-shell.c
@@ -1,0 +1,1151 @@
+/* ds1963s-shell.c
+ *
+ * A interactive utility for ds1963s experimentation.
+ *
+ * Dedicated to Yuzuyu Arielle Huizer.
+ *
+ * Copyright (C) 2019  Ronald Huizer <rhuizer@hexpedition.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include <stdio.h>
+#include <getopt.h>
+#include <readline/readline.h>
+#include <readline/history.h>
+#include "ds1963s-client.h"
+#include "ds1963s-common.h"
+
+#define DEFAULT_SERIAL_PORT	"/dev/ttyUSB0"
+
+static struct ds1963s_client client;
+
+static int
+__cmd_is_help(const char *cmd)
+{
+	if (cmd[0] != 'h') return 0;
+	if (!strcmp(cmd, "h")) return 1;
+	if (!strcmp(cmd, "help")) return 1;
+	return 0;
+}
+
+static int
+__cmd_is_rom(const char *cmd)
+{
+	if (cmd[0] != 'r') return 0;
+	if (!strcmp(cmd, "rom")) return 1;
+	return 0;
+}
+
+static int
+__cmd_is_set(const char *cmd)
+{
+	if (cmd[0] != 's') return 0;
+	if (!strcmp(cmd, "set")) return 1;
+	return 0;
+}
+
+static int
+__cmd_is_write_scratchpad(const char *cmd)
+{
+	if (cmd[0] != 'w') return 0;
+	if (!strcmp(cmd, "wsp")) return 1;
+	if (!strcmp(cmd, "write-scratchpad")) return 1;
+	return 0;
+
+}
+
+static int
+__cmd_is_read_scratchpad(const char *cmd)
+{
+	if (cmd[0] != 'r') return 0;
+	if (!strcmp(cmd, "rsp")) return 1;
+	if (!strcmp(cmd, "read-scratchpad")) return 1;
+	return 0;
+
+}
+
+static int
+__cmd_is_copy_scratchpad(const char *cmd)
+{
+	if (cmd[0] != 'c') return 0;
+	if (!strcmp(cmd, "csp")) return 1;
+	if (!strcmp(cmd, "copy-scratchpad")) return 1;
+	return 0;
+}
+
+static int
+__cmd_is_read_memory(const char *cmd)
+{
+	if (cmd[0] != 'r') return 0;
+	if (!strcmp(cmd, "rm")) return 1;
+	if (!strcmp(cmd, "read-memory")) return 1;
+	return 0;
+}
+
+static int
+__cmd_is_erase_scratchpad(const char *cmd)
+{
+	if (cmd[0] != 'e') return 0;
+	if (!strcmp(cmd, "esp")) return 1;
+	if (!strcmp(cmd, "erase-scratchpad")) return 1;
+	return 0;
+}
+
+static int
+__cmd_is_match_scratchpad(const char *cmd)
+{
+	if (cmd[0] != 'm') return 0;
+	if (!strcmp(cmd, "msp")) return 1;
+	if (!strcmp(cmd, "match-scratchpad")) return 1;
+	return 0;
+}
+
+static int
+__cmd_is_read_auth_page(const char *cmd)
+{
+	if (cmd[0] != 'r') return 0;
+	if (!strcmp(cmd, "read-auth-page")) return 1;
+	if (!strcmp(cmd, "rap")) return 1;
+	if (!strcmp(cmd, "ra")) return 1;
+	return 0;
+}
+
+static int
+__cmd_is_sha(const char *cmd)
+{
+	if (cmd[0] != 's') return 0;
+	if (!strcmp(cmd, "sha-command")) return 1;
+	if (!strcmp(cmd, "sha")) return 1;
+	return 0;
+}
+
+static int
+__cmd_is_compute_first_secret(const char *cmd)
+{
+	if (cmd[0] != 'c') return 0;
+	if (!strcmp(cmd, "compute-first-secret")) return 1;
+	if (!strcmp(cmd, "cfs")) return 1;
+	return 0;
+}
+
+static int
+__cmd_is_compute_next_secret(const char *cmd)
+{
+	if (cmd[0] != 'c') return 0;
+	if (!strcmp(cmd, "compute-next-secret")) return 1;
+	if (!strcmp(cmd, "cns")) return 1;
+	return 0;
+}
+
+static int
+__cmd_is_validate_data_page(const char *cmd)
+{
+	if (cmd[0] != 'v') return 0;
+	if (!strcmp(cmd, "validate-data-page")) return 1;
+	if (!strcmp(cmd, "validate")) return 1;
+	if (!strcmp(cmd, "vdp")) return 1;
+	return 0;
+}
+
+static int
+__cmd_is_sign_data_page(const char *cmd)
+{
+	if (cmd[0] != 's') return 0;
+	if (!strcmp(cmd, "sign-data-page")) return 1;
+	if (!strcmp(cmd, "sign")) return 1;
+	if (!strcmp(cmd, "sdp")) return 1;
+	return 0;
+}
+
+static int
+__cmd_is_compute_challenge(const char *cmd)
+{
+	if (cmd[0] != 'c') return 0;
+	if (!strcmp(cmd, "compute-challenge")) return 1;
+	if (!strcmp(cmd, "challenge")) return 1;
+	if (!strcmp(cmd, "cc")) return 1;
+	return 0;
+}
+
+static int
+__cmd_is_authenticate_host(const char *cmd)
+{
+	if (cmd[0] != 'a') return 0;
+	if (!strcmp(cmd, "authenticate-host")) return 1;
+	if (!strcmp(cmd, "auth")) return 1;
+	if (!strcmp(cmd, "ah")) return 1;
+	return 0;
+}
+
+static int
+parse_uint(const char *s, unsigned int *p)
+{
+	unsigned int i;
+	char *endptr;
+
+	i = strtoul(s, &endptr, 0);
+	if (*s == 0 || *endptr != 0) {
+		printf("Invalid number \"%s\".\n", s);
+		return -1;
+	}
+
+	*p = i;
+	return 0;
+}
+
+static int
+byte_get(const char *function, uint8_t *value)
+{
+	unsigned int _value;
+	char *s;
+
+	if ( (s = strtok(NULL, " \t")) == NULL) {
+		printf("%s expects a byte\n", function);
+		return -1;
+	}
+
+	if (parse_uint(s, &_value) == -1)
+		return -1;
+
+	if (_value > 255) {
+		printf("A byte should be less than or equal to 255.\n");
+		return -1;
+	}
+
+	*value = _value;
+	return 0;
+}
+
+static int
+bool_get(const char *function, int *value)
+{
+	unsigned int _value;
+	char *s;
+
+	if ( (s = strtok(NULL, " \t")) == NULL) {
+		printf("%s expects a boolean\n", function);
+		return -1;
+	}
+
+	if (parse_uint(s, &_value) == -1)
+		return -1;
+
+	if (_value > 1) {
+		printf("A boolean should be either 0 or 1.\n");
+		return -1;
+	}
+
+	*value = _value;
+	return 0;
+}
+
+static int
+address_symbolic_get(const char *s)
+{
+	if (!strcmp(s, "pctr") || !strcmp(s, "prng") ||
+	    !strcmp(s, "PRNG")) {
+		return 0x2a0;
+	} else if (!strcmp(s, "hash")) {
+		return 0x248;
+	} else if (!strcmp(s, "sp") || !strcmp(s, "scratchpad")) {
+		return 0x240;
+	}
+
+	return -1;
+}
+
+static int
+address_get(const char *function, int *address)
+{
+	unsigned int _address;
+	char *s;
+
+	if ( (s = strtok(NULL, " \t")) == NULL) {
+		printf("%s expects an address\n", function);
+		return -1;
+	}
+
+	if ( (_address = address_symbolic_get(s)) != -1) {
+		*address = _address;
+		return 0;
+	}
+
+	if (parse_uint(s, &_address) == -1)
+		return -1;
+
+	if (_address > 0xFFFF) {
+		printf("Address should be in range [0, 0xFFFF]\n");
+		return -1;
+	}
+
+	*address = _address;
+	return 0;
+}
+
+void
+handle_copy_scratchpad(void)
+{
+	unsigned int address, es;
+	char *s;
+
+	if ( (s = strtok(NULL, " \t")) == NULL) {
+		printf("copy expects an address\n");
+		return;
+	}
+
+	if (parse_uint(s, &address) == -1)
+		return;
+
+	if ( (s = strtok(NULL, " \t")) == NULL) {
+		printf("copy expects E/S\n");
+		return;
+	}
+
+	if (parse_uint(s, &es) == -1)
+		return;
+
+	if (ds1963s_client_sp_copy(&client, address, es) == -1)
+		ds1963s_client_perror(&client, NULL);
+}
+
+void
+handle_erase_scratchpad(void)
+{
+	unsigned int address;
+	char *s;
+
+	if ( (s = strtok(NULL, " \t")) == NULL) {
+		address = 0;
+	} else if (parse_uint(s, &address) == -1) {
+		return;
+	}
+
+	if (ds1963s_client_sp_erase(&client, address) == -1) {
+		ds1963s_client_perror(&client, NULL);
+		return;
+	}
+}
+
+void handle_match_scratchpad(void)
+{
+	uint8_t hash[20] = { 0 };
+	int     ret;
+	char *  s;
+
+	if ( (s = strtok(NULL, " \t")) == NULL || strlen(s) != 40) {
+		printf("match expects a 20 bytes of hexadecimal data\n");
+		return;
+	}
+
+	if (hex_decode(hash, s, 20) == -1) {
+		printf("match expects a 20 bytes of hexadecimal data\n");
+		return;
+	}
+
+	if ( (ret = ds1963s_client_sp_match(&client, hash)) == -1) {
+		ds1963s_client_perror(&client, NULL);
+		return;
+	}
+
+	printf("%s\n", ret ? "MATCH" : "MISMATCH");
+}
+
+void
+handle_read_scratchpad(void)
+{
+	ds1963s_client_sp_read_reply_t reply;
+	uint8_t  TA1, TA2;
+	int      page;
+
+	if (ds1963s_client_sp_read(&client, &reply) == -1) {
+		ds1963s_client_perror(&client, NULL);
+		return;
+	}
+
+	ds1963s_address_to_ta(reply.address, &TA1, &TA2);
+	page = ds1963s_address_to_page(reply.address);
+
+	printf("Address: 0x%-5.4x (Page   : %d)\n", reply.address, page);
+	printf("TA1    : 0x%-5.2x (", TA1);
+	printf("T07:T00:");
+	for (int i = 7; i >= 0; i--)
+		printf("%s %d", i != 7 ? "," : "", (TA1 >> i) & 1);
+	printf(")\n");
+
+	printf("TA2    : 0x%-5.2x (", TA2);
+	printf("T15:T08:");
+	for (int i = 7; i >= 0; i--)
+		printf("%s %d", i != 7 ? "," : "", (TA2 >> i) & 1);
+	printf(")\n");
+
+	printf("E/S    : 0x%.2x\n", reply.es);
+	printf("E      : 0x%-5.2x (", reply.es & 0x1F);
+	printf("E04:E00:");
+	for (int i = 4; i >= 0; i--)
+		printf("%s %d", i != 4 ? "," : "", (reply.es >> i) & 1);
+	printf(")\n");
+	printf("PF     : %d\n", !!(reply.es & 0x20));
+	printf("AA     : %d\n", !!(reply.es & 0x80));
+
+	printf("CRC16  : 0x%-5.4x (%s)\n",
+	       reply.crc16, reply.crc_ok ? "OK" : "WRONG");
+
+	printf("Offset : %-7d (", TA1 & 0x1F);
+	printf("T04:T00:");
+	for (int i = 4; i >= 0; i--)
+		printf("%s %d", i != 4 ? "," : "", (TA1 >> i) & 1);
+	printf(")\n");
+	printf("Length : %-7d\n", 32 - (TA1 & 0x1F));
+
+	printf("Data   : ");
+	for (int i = 0; i < reply.data_size; i++)
+		printf("%.2x", reply.data[i]);
+	printf("\n");
+}
+
+void
+handle_write_scratchpad(void)
+{
+	unsigned int address;
+	uint8_t      data[32];
+	char *       s;
+	ssize_t      n;
+
+	if ( (s = strtok(NULL, " \t")) == NULL) {
+		printf("write expects an address\n");
+		return;
+	}
+
+	if (parse_uint(s, &address) == -1)
+		return;
+
+	if ( (s = strtok(NULL, " \t")) == NULL) {
+		printf("write expects up to 32 bytes of hexadecimal data\n");
+		return;
+	}
+
+	if ( (n = hex_decode(data, s, 32)) < 0) {
+		printf("Invalid hex data \"%s\".\n", s);
+		return;
+	}
+
+	if (ds1963s_client_sp_write(&client, address, data, n) == -1)
+		ds1963s_client_perror(&client, NULL);
+}
+
+void
+handle_read_memory(void)
+{
+	uint8_t      buf[157];
+	int          address;
+	unsigned int size;
+	char *       s;
+
+	if (address_get("read-memory", &address) == -1)
+		return;
+
+	if ( (s = strtok(NULL, " \t")) == NULL) {
+		printf("read expects a size\n");
+		return;
+	}
+
+	if (parse_uint(s, &size) == -1)
+		return;
+
+	if (ds1963s_client_memory_read(&client, address, buf, size) == -1) {
+		ds1963s_client_perror(&client, NULL);
+		return;
+	}
+
+	hexdump(buf, size, address);
+}
+
+void
+handle_read_auth_page(void)
+{
+	ds1963s_client_read_auth_page_reply_t reply;
+	int address;
+
+	if (address_get("read-auth-page", &address) == -1)
+		return;
+
+	if (ds1963s_client_read_auth(&client, address, &reply) == -1) {
+		ds1963s_client_perror(&client, NULL);
+		return;
+	}
+
+	printf("W/C page  : 0x%.8x\n", reply.data_wc);
+	printf("W/C secret: 0x%.8x\n", reply.secret_wc);
+	printf("CRC16     : 0x%.4x  (%s)\n",
+		reply.crc16, reply.crc_ok ? "OK" : "WRONG");
+	printf("Data      : ");
+	for (int i = 0; i < reply.data_size; i++)
+		printf("%.2x", reply.data[i]);
+	printf("\n");
+}
+
+void handle_sha_command(void)
+{
+	int     address;
+	uint8_t cmd;
+
+	if (byte_get("sha-command", &cmd) == -1)
+		return;
+
+	if (address_get("sha-command", &address) == -1)
+		return;
+
+	if (ds1963s_client_sha_command(&client, cmd, address) == -1) {
+		ds1963s_client_perror(&client, NULL);
+		return;
+	}
+}
+
+void
+handle_compute_first_secret(void)
+{
+	int address;
+
+	if (address_get("compute-first-secret", &address) == -1)
+		return;
+
+	if (ds1963s_client_secret_compute_first(&client, address) == -1) {
+		ds1963s_client_perror(&client, NULL);
+		return;
+	}
+}
+
+void
+handle_compute_next_secret(void)
+{
+	int address;
+
+	if (address_get("compute-next-secret", &address) == -1)
+		return;
+
+	if (ds1963s_client_secret_compute_next(&client, address) == -1) {
+		ds1963s_client_perror(&client, NULL);
+		return;
+	}
+}
+
+void
+handle_validate_data_page(void)
+{
+	int address;
+
+	if (address_get("validate-data-page", &address) == -1)
+		return;
+
+	if (ds1963s_client_validate_data_page(&client, address) == -1) {
+		ds1963s_client_perror(&client, NULL);
+		return;
+	}
+}
+
+void
+handle_sign_data_page(void)
+{
+	int address;
+
+	if (address_get("sign-data-page", &address) == -1)
+		return;
+
+	if (ds1963s_client_sign_data_page(&client, address) == -1) {
+		ds1963s_client_perror(&client, NULL);
+		return;
+	}
+}
+
+static void
+__warn_page_0_8(int address)
+{
+	int is_p0, is_p8;
+
+	is_p0 = address >=   0 && address <  32;
+	is_p8 = address >= 256 && address < 288;
+
+	if (is_p0 || is_p8)
+		printf("INFO: The datasheet specifies this function will fail "
+		       "when used on pages 0 and 8.\n");
+}
+
+void
+handle_compute_challenge(void)
+{
+	int address;
+
+	if (address_get("compute-challenge", &address) == -1)
+		return;
+
+	if (ds1963s_client_compute_challenge(&client, address) == -1) {
+		ds1963s_client_perror(&client, NULL);
+		__warn_page_0_8(address);
+		return;
+	}
+}
+
+void
+handle_authenticate_host(void)
+{
+	int address;
+
+	if (address_get("authenticate-host", &address) == -1)
+		return;
+
+	if (ds1963s_client_authenticate_host(&client, address) == -1) {
+		ds1963s_client_perror(&client, NULL);
+		__warn_page_0_8(address);
+		return;
+	}
+}
+
+void
+handle_main_help(void)
+{
+	printf("List of commands:\n\n");
+	printf("rom                       -- Lists the ROM serial\n");
+	printf("set                       -- Manage setting variables\n");
+	printf("help, h                   -- This help menu\n");
+
+	printf("\nList of memory commands:\n\n");
+	printf("write-scratchpad,     wsp -- Write data to the scratchpad\n");
+	printf("read-scratchpad,      rsp -- Read data from the scratchpad\n");
+	printf("copy-scratchpad,      csp -- Copy scratchpad data to memory\n");
+	printf("read-memory,          rm  -- Read data from memory\n");
+	printf("erase-scratchpad,     esp -- Erase the scratchpad\n");
+	printf("match-scratchpad,     msp -- Match the scratchpad to data\n");
+	printf("read-auth-page,       rap -- Read authenticated page\n");
+
+	printf("\nList of SHA commands:\n\n");
+	printf("compute-first-secret, cfs -- Compute the first secret\n");
+	printf("compute-next-secret,  cns -- Compute the next secret\n");
+	printf("validate-data-page,   vdp -- Validate a page in memory\n");
+	printf("sign-data-page,       sdp -- Sign a page in memory\n");
+	printf("compute-challenge,    cc  -- Compute a challenge\n");
+	printf("authenticate-host,    ah  -- Authenticate a host\n");
+}
+
+void
+handle_help(void)
+{
+	char *arg;
+
+	if ( (arg = strtok(NULL, " \t")) == NULL) {
+		handle_main_help();
+		return;
+	}
+
+	if (__cmd_is_write_scratchpad(arg)) {
+		printf("write-scratchpad, wsp <addr> <data>\n\n"
+
+		       "This command writes the hex encoded data in `data' "
+		       "to the scratchpad at address\n"
+		       "`addr'.  Only T4:T0 (that is, the least significant "
+		       "5 bits of the address) are\n"
+		       "used and encode the scratchpad offset to start "
+		       "writing to.  Data is encoded in\n"
+		       "plain hexadecimal format.\n\n"
+
+		       "Note that the scratchpad area is 32-bytes large.\n\n"
+
+		       "Examples:\n\n"
+
+		       "- wsp 0 41424344\n"
+		       "  Writes the string \"ABCD\" to the scratchpad "
+		       "starting at offset 0.\n\n"
+		       "- wsp 24 0000000000000000\n"
+		       "  Sets the last 8 bytes of the scratchpad to 0.\n"
+		);
+	} else if (__cmd_is_read_scratchpad(arg)) {
+		printf("read-scratchpad, rsp\n\n"
+
+		       "This command will read the TA1, TA2, and E/S "
+		       "registers and scratchpad data\n"
+		       "starting at offset T4:T0 from the device and "
+		       "display the results.\n\n"
+
+		       "Note that because no address is provided, the "
+		       "scratchpad data offset is\n"
+		       "based on a previous value of the T4:T0.\n\n"
+
+		       "The output is verbose, and presents collected "
+		       "information in various forms.\n"
+		);
+	} else if (__cmd_is_copy_scratchpad(arg)) {
+		printf("copy-scratchpad, csp <addr> <es>\n\n"
+
+		       "This command copies data from the scratchpad to "
+		       "memory.  The address in `addr'\n"
+		       "and the E/S byte in `es' are used as an "
+		       "authorization pattern.  If they are\n"
+		       "equal to the address in TA1 and TA2, and the E/S "
+		       "byte on the device then the\n"
+		       "copy will proceed.  In this case the AA flag will "
+		       "be set.\n\n"
+
+		       "The source of the copy starts at offset TA4:TA0 and "
+		       "ends at offset E/S,\n"
+		       "inclusive.  The destination of the copy starts at "
+		       "the address (TA2:TA1) and\n"
+		       "ends at offset E/S in the page of that address.\n\n"
+
+		       "Example:\n\n"
+
+		       "esp\n"
+		       "wsp 63 41\n"
+		       "csp 63 31\n"
+		       "rsp\n\n"
+		       "This sequence will erase the scratchpad, set the "
+		       "address to 63, write the\n"
+		       "character 'A' to offset 31 (T4:T0 -- the 5 least "
+		       "significant bits of 63) and\n"
+		       "set E/S to 31.  The copy command will then authorize "
+		       "using the same values as\n"
+		       "in TA2:TA1 and E/S, and copy the byte at scratchpad "
+		       "offset 31 to memory address\n"
+		       "63.  The copy ends because E/S is 31.  The AA flag "
+		       "should be set in the final\n"
+		       "rsp command.\n"
+		);
+	} else if (__cmd_is_read_memory(arg)) {
+		printf("read-memory, rm <addr> <size>\n\n"
+		       "This command will read `size' bytes of data "
+		       "starting at address `addr' and\n"
+		       "display a hexdump of the data read.\n\n"
+
+		       "The address registers on the device will be updated "
+		       "to point to the last\n"
+		       "address read from.  The E/S byte is not affected.\n\n"
+
+		       "Examples:\n\n"
+
+		       "- rm 0 32\n"
+		       "  Display a hexdump of 32-bytes of data at address "
+		       "0.\n\n"
+
+		       "- rm 0x0200 0\n"
+		       "This will not read actual data but just set TA2 to"
+		       "0x02 and TA1 to 0x00.\n"
+		);
+	} else if (__cmd_is_erase_scratchpad(arg)) {
+		printf("erase-scratchpad, esp [addr]\n\n"
+
+		       "This command will erase the full 32-byte scratchpad "
+		       "by filling it with 0xFF\n"
+		       "bytes.  The address in `addr' is latched into the "
+		       "TA2 and TA1 registers but is not used\n"
+		       "any further.  If `addr' is not specified it will use "
+		       "the default value of 0.\n"
+		       "Finally the HIDE flag will be set to 0, which is the "
+		       "only way this can be done.\n\n"
+
+		       "Examples:\n\n"
+
+		       "- esp\n"
+		       "  Will set all scratchpad bytes to 0xFF, TA2 to 0x00, "
+		       "and TA1 to 0x00.\n\n"
+
+		       "- esp 0x123\n"
+		       "  Will set all scratchpad bytes to 0xFF, TA2 to 0x01, "
+		       "and TA1 to 0x23.\n"
+		);
+	} else if (__cmd_is_match_scratchpad(arg)) {
+		printf("match-scratchpad, esp <data>\n\n"
+
+		       "This command will compare 20 bytes of hex encoded "
+		       "data in `data' to 20 bytes on\n"
+		       "the scratchpad starting at offset 8.  This scratchpad "
+		       "location is used by other\n"
+		       "functions to store a 20 byte SHA-1 hash.\n"
+		       "If the AUTH flag was set, the MATCH flag will be "
+		       "set.\n\n"
+
+		       "Examples:\n\n"
+
+		       "- msp 4141414141414141414142424242424242424242\n"
+		       "  Will compare bytes at scratchpad[8] through "
+		       "scratchpad[27] (inclusive) to the\n"
+		       "  string \"AAAAAAAAAABBBBBBBBBB\" and report whether "
+		       "there was a match or a mismatch.\n"
+		);
+	} else if (__cmd_is_read_auth_page(arg)) {
+		printf("read-auth-page, rap <addr>\n\n"
+
+		       "This command will read data at address `addr' up to "
+		       "and including offset 31 in\n"
+		       "the page that address is in and return it.  "
+		       "Furthermore, the write-cycle\n"
+		       "counter of the page and the write-cycle counter of "
+		       "the secret associated with\n"
+		       "that page will be returned.\n\n"
+
+		       "Finally, a 20 byte SHA-1 based message authentication "
+		       "code over the full page\n"
+		       "data (not just the data read/returned), the secret "
+		       "associated with the page,\n"
+		       "the write cycle-counters, the page number, the device "
+		       "serial, and 3 bytes of\n"
+		       "scratchpad data is stored on the scratchpad starting "
+		       "at offset 8.\n\n"
+
+		       "Examples:\n\n"
+
+		       "- rap 0\n"
+		       "  Reads 32 bytes of data on page 0, the W/C of page "
+		       "0, and the W/C of secret 0.\n"
+		       "  Stores the MAC as discussed above starting at "
+		       "SP[8].\n\n"
+
+		       "- rap 31\n"
+		       "  Reads 1 byte of data from address 31, the W/C of "
+		       "page 0, and the W/C of\n"
+		       "  secret 0.  Stores the MAC as discussed above "
+		       "starting at SP[8].\n"
+		);
+	} else if (__cmd_is_compute_first_secret(arg)) {
+		printf("compute-first-secret, cfs <addr>\n\n"
+
+		       "This command computes a SHA-1 based message "
+		       "authentication code over a NULL\n"
+		       "secret (that is, eight 0x00 bytes), the full "
+		       "32-bytes data of the page that the\n"
+		       "address `addr' is in, and 15 bytes of scratchpad "
+		       "data from SP[8] to SP[22]\n"
+		       "(inclusive).  The address is latched into registers "
+		       "TA2 and TA1 on the device.\n\n"
+
+		       "The result of this function repeatedly stores 8 bytes "
+		       "of the resulting MAC on\n"
+		       "the scratchpad until it is filled.  This will happen "
+		       "4 times in total.\n\n"
+
+		       "The HIDE flag will be set, so afterwards data from "
+		       "the scratchpad can be copied\n"
+		       "to secret memory using the copy-scratchpad command "
+		       "immediately.  The repetition\n"
+		       "above means we data can be written to any of the "
+		       "secrets, and up to 4 secrets\n"
+		       "can be written at once.\n\n"
+
+		       "Examples:\n\n"
+		       "- cfs 0\n"
+		       "  Calculates the SHA-1 MAC over a NULL secret, the "
+		       "data in page 0, and 15 bytes\n"
+		       "  of scratchpad data.  The scratchpad is filled by "
+		       "storing 8 bytes of the\n"
+		       "  calculated MAC 4 times.  TA2 and TA1 will both me "
+		       "set to 0.\n\n"
+
+		       "- cfs 0x13\n"
+		       "  Calculates the SHA-1 MAC over a NULL secret, the "
+		       "data in page 0, and 15 bytes\n"
+		       "  of scratchpad data.  The scratchpad is filled by "
+		       "storing 8 bytes of the\n"
+		       "  calculated MAC 4 times.  TA2 will be set to 0, TA1 "
+		       "will be set to 0x13.\n"
+		);
+	} else if (__cmd_is_compute_next_secret(arg)) {
+		printf("compute-next-secret, cns <addr>\n\n"
+
+		       "This command computes a SHA-1 based message "
+		       "authentication code over the secret\n"
+		       "associated with `addr', the full 32-bytes data of the "
+		       "page that the address\n"
+		       "`addr' is in, and 15 bytes of scratchpad data from "
+		       "SP[8] to SP[22] (inclusive).\n"
+		       "The address is latched into registers TA2 and TA1 on "
+		       "the device.\n\n"
+
+		       "The result of this function repeatedly stores 8 bytes "
+		       "of the resulting MAC on\n"
+		       "the scratchpad until it is filled.  This will happen "
+		       "4 times in total.\n\n"
+
+		       "The HIDE flag will be set, so afterwards data from "
+		       "the scratchpad can be copied\n"
+		       "to secret memory using the copy-scratchpad command "
+		       "immediately.  The repetition\n"
+		       "above means we data can be written to any of the "
+		       "secrets, and up to 4 secrets\n"
+		       "can be written at once.\n\n"
+
+		       "Examples:\n\n"
+
+		       "- cns 0\n"
+		       "  Calculates the SHA-1 MAC over secret 0, the "
+		       "data in page 0, and 15 bytes\n"
+		       "  of scratchpad data.  The scratchpad is filled by "
+		       "storing 8 bytes of the\n"
+		       "  calculated MAC 4 times.  TA2 and TA1 will both me "
+		       "set to 0.\n\n"
+
+		       "- cns 0x13\n"
+		       "  Calculates the SHA-1 MAC over a secret 0, the "
+		       "data in page 0, and 15 bytes\n"
+		       "  of scratchpad data.  The scratchpad is filled by "
+		       "storing 8 bytes of the\n"
+		       "  calculated MAC 4 times.  TA2 will be set to 0, TA1 "
+		       "will be set to 0x13.\n"
+		);
+	} else if (__cmd_is_validate_data_page(arg)) {
+		printf("validate-data-page, validate, vdp <addr>\n\n"
+
+		       "This command will calculate a SHA-1 message "
+		       "authentication code over the full\n"
+		       "32-byte data in the page that `addr' belongs to, "
+		       "the associated secret, and 15\n"
+		       "bytes of scratchpad data from SP[8] to SP[22] "
+		       "(inclusive).  This 160-bit SHA-1\n"
+		       "MAC is then stored at SP[8] to SP[20] (inclusive) and "
+		       "the HIDE flag is set.\n"
+		       "TA1 and TA2 will be set to the address `addr'.\n\n"
+
+		       "The command can be used to validate data in a data "
+		       "page.  It is meant to be\n"
+		       "used in combination with the match-scratchpad "
+		       "function, and can be used to\n"
+		       "prove to the device that a secret associated with a "
+		       "data page is known.\n\n"
+
+		       "Example:\n\n"
+		       "  ds1963s> esp\n"
+		       "  ds1963s> sdp 0\n"
+		       "  ds1963s> rsp\n"
+		       "  Address: 0x0000  (Page   : 0)\n"
+		       "  TA1    : 0x00    (T07:T00: 0, 0, 0, 0, 0, 0, 0, 0)\n"
+		       "  TA2    : 0x00    (T15:T08: 0, 0, 0, 0, 0, 0, 0, 0)\n"
+		       "  E/S    : 0x1f\n"
+		       "  E      : 0x1f    (E04:E00: 1, 1, 1, 1, 1)\n"
+		       "  PF     : 0\n"
+		       "  AA     : 0\n"
+		       "  CRC16  : 0x33e1  (OK)\n"
+		       "  Offset : 0       (T04:T00: 0, 0, 0, 0, 0)\n"
+		       "  Length : 32\n"
+		       "  Data   : ffffffffffffffff42bd425d27fb70e43df23ab8aed"
+		       "59b90d81b718cffffffff\n"
+		       "  ds1963s> esp\n"
+		       "  ds1963s> vdp 0\n"
+		       "  ds1963s> msp 42bd425d27fb70e43df23ab8aed59b90d81b71"
+		       "8c\n"
+		       "  MATCH\n"
+		);
+	} else if (__cmd_is_sign_data_page(arg)) {
+		printf("sign-data-page, sign, sdp <addr>\n\n"
+
+		       "This command will calculate a SHA-1 message "
+		       "authentication code over the full\n"
+                       "32-byte data in the page that `addr' belongs to, the "
+		       "associated secret, and 15\n"
+		       "bytes of scratchpad data from SP[8] to SP[22] "
+		       "(inclusive).  This 160-bit SHA-1\n"
+		       "MAC is then stored at SP[8] to SP[20] (inclusive).  "
+		       "TA1 and TA2 will be set to\n"
+		       "the address `addr'.\n\n"
+
+		       "The command can be used to sign data in a data page, "
+		       "and this signature can\n"
+		       "then be verified by anyone who knows the secret.\n\n"
+
+			"Examples:\n\n"
+
+		        "- sdp 0\n"
+		        "  Will calculate a SHA-1 MAC over the 32-bytes in "
+			"page 0, secret 0, and the\n"
+		        "  data at SP[8] to SP[20] (inclusive).  This MAC is "
+			"stored at SP[8] to SP[20]\n"
+		        "  inclusive.  TA2 is set to 0 and TA1 is set to 0."
+			"\n\n"
+
+			"- sdp 0x13\n"
+		        "  Will calculate a SHA-1 MAC over the 32-bytes in "
+			"page 0, secret 0, and the\n"
+		        "  data at SP[8] to SP[20] (inclusive).  This MAC is "
+			"stored at SP[8] to SP[20]\n"
+		        "  inclusive.  TA2 is set to 0 and TA1 is set to 0x13."
+			"\n"
+		);
+	} else if (__cmd_is_compute_challenge(arg)) {
+		printf("This is a stub entry.\n");
+	} else if (__cmd_is_authenticate_host(arg)) {
+		printf("This is a stub entry.\n");
+	} else {
+		printf("Unknown command: \"%s\".  Try \"help\".\n", arg);
+	}
+}
+
+void
+handle_rom(void)
+{
+        ds1963s_rom_t rom;
+
+        ds1963s_client_rom_get(&client, &rom);
+
+	printf("Data  : ");
+	for (int i = 0; i < sizeof rom.raw; i++)
+		printf("%.2x", rom.raw[i]);
+	printf("\n");
+
+	printf("Family: 0x%.2x\n", rom.family);
+
+	printf("Serial: ");
+	for (int i = 0; i < sizeof rom.serial; i++)
+		printf("%.2x", rom.serial[i]);
+	printf("\n");
+
+	printf("CRC8  : 0x%.2x  (%s)\n", rom.crc, rom.crc_ok ? "OK" : "WRONG");
+}
+
+void
+handle_set(void)
+{
+	char *arg;
+	int   b;
+
+	if ( (arg = strtok(NULL, " \t")) == NULL) {
+		printf("resume: %d\n", client.resume);
+		return;
+	}
+
+	if (!strcmp(arg, "resume")) {
+		if (bool_get("set resume", &b) == -1)
+			return;
+		client.resume = b;
+	} else {
+		printf("Unknown setting: \"%s\".  Try \"help\".\n", arg);
+	}
+}
+
+void
+handle_command(char *line)
+{
+	char *cmd;
+
+	if ( (cmd = strtok(line, " \t")) == NULL)
+		return;
+
+	if (__cmd_is_help(cmd)) {
+		handle_help();
+	} else if (__cmd_is_rom(cmd)) {
+		handle_rom();
+	} else if (__cmd_is_set(cmd)) {
+		handle_set();
+	} else if (__cmd_is_write_scratchpad(cmd)) {
+		handle_write_scratchpad();
+	} else if (__cmd_is_read_scratchpad(cmd)) {
+		handle_read_scratchpad();
+	} else if (__cmd_is_copy_scratchpad(cmd)) {
+		handle_copy_scratchpad();
+	} else if (__cmd_is_read_memory(cmd)) {
+		handle_read_memory();
+	} else if (__cmd_is_erase_scratchpad(cmd)) {
+		handle_erase_scratchpad();
+	} else if (__cmd_is_match_scratchpad(cmd)) {
+		handle_match_scratchpad();
+	} else if (__cmd_is_read_auth_page(cmd)) {
+		handle_read_auth_page();
+	} else if (__cmd_is_compute_first_secret(cmd)) {
+		handle_compute_first_secret();
+	} else if (__cmd_is_compute_next_secret(cmd)) {
+		handle_compute_next_secret();
+	} else if (__cmd_is_validate_data_page(cmd)) {
+		handle_validate_data_page();
+	} else if (__cmd_is_sign_data_page(cmd)) {
+		handle_sign_data_page();
+	} else if (__cmd_is_compute_challenge(cmd)) {
+		handle_compute_challenge();
+	} else if (__cmd_is_authenticate_host(cmd)) {
+		handle_authenticate_host();
+	} else if (__cmd_is_sha(cmd)) {
+		handle_sha_command();
+	} else {
+		printf("Unknown command: \"%s\".  Try \"help\".\n", cmd);
+	}
+}
+
+void
+usage(const char *progname)
+{
+	fprintf(stderr, "Use as: %s [OPTION]\n",
+	        progname ? progname : "ds1963s-shell");
+	fprintf(stderr, "Available options:\n");
+	fprintf(stderr, "   -d --device=pathname  the serial device used.\n");
+	fprintf(stderr, "   -h --help             this help menu.\n");
+}
+
+static const struct option options[] = {
+	{ "device", 1, NULL, 'd' },
+	{ "help",   0, NULL, 'h' }
+};
+
+const char optstr[] = "d:h";
+
+const char banner[] =
+"`7MM\"\"\"Yb.    .M\"\"\"bgd                  .6*\"            .M\"\"\"bgd\n"
+"  MM    `Yb. ,MI    \"Y __,            ,M'              ,MI    \"Y\n"
+"  MM     `Mb `MMb.    `7MM  .d*\"*bg. ,Mbmmm.   pd\"\"b.  `MMb.\n"
+"  MM      MM   `YMMNq.  MM 6MP    Mb 6M'  `Mb.(O)  `8b   `YMMNq.\n"
+"  MM     ,MP .     `MM  MM YMb    MM MI     M8     ,89 .     `MM\n"
+"  MM    ,dP' Mb     dM  MM  `MbmmdM9 WM.   ,M9   \"\"Yb. Mb     dM\n"
+".JMMmmmdP'   P\"Ybmmd\" .JMML.     .M'  WMbmmd9       88 P\"Ybmmd\"\n"
+"                               .d9            (O)  .M'\n"
+"                             m\"'               bmmmd'\n"
+"\n"
+"     .M\"\"\"bgd `7MMF'  `7MMF'`7MM\"\"\"YMM  `7MMF'      `7MMF'\n"
+"    ,MI    \"Y   MM      MM    MM    `7    MM          MM\n"
+"    `MMb.       MM      MM    MM   d      MM          MM\n"
+"      `YMMNq.   MMmmmmmmMM    MMmmMM      MM          MM\n"
+"    .     `MM   MM      MM    MM   Y  ,   MM      ,   MM      ,\n"
+"    Mb     dM   MM      MM    MM     ,M   MM     ,M   MM     ,M\n"
+"    P\"Ybmmd\"  .JMML.  .JMML..JMMmmmmMMM .JMMmmmmMMM .JMMmmmmMMM\n"
+"\n"
+"                           For Yuzu\n"
+"                       By Ronald Huizer\n\n";
+
+int
+main(int argc, char **argv)
+{
+	const char *device_name;
+	char *line;
+	int   i, o;
+
+	device_name = DEFAULT_SERIAL_PORT;
+	while ( (o = getopt_long(argc, argv, optstr, options, &i)) != -1) {
+		switch (o) {
+		case 'd':
+			device_name = optarg;
+			break;
+		case 'h':
+			usage(argv[0]);
+			exit(EXIT_SUCCESS);
+		}
+	}
+
+	printf("\n%s", banner);
+
+	if (ds1963s_client_init(&client, device_name) == -1) {
+		ds1963s_client_perror(&client, "ds1963s_client_init()");
+		exit(EXIT_FAILURE);
+	}
+
+	while ( (line = readline("ds1963s> ")) != NULL) {
+		if (*line != 0) {
+			add_history(line);
+			handle_command(line);
+		}
+		free(line);
+	}
+
+	exit(EXIT_SUCCESS);
+}

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ds1963s-tool-yaml.c
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ds1963s-tool-yaml.c
@@ -1,0 +1,292 @@
+/* ds1963s-tool-yaml.c
+ *
+ * Emit a yaml configuration defining the ds1963s ibutton dumped.
+ *
+ * Dedicated to Yuzuyu Arielle Huizer.
+ *
+ * Not a fan of libyaml in C, this code is a horribly convoluted state machine.
+ * Either I've gotten the use wrong, or the design of libyaml is bad.  Instead
+ * of saving time and work it wasted and created it, which is the opposite of
+ * what a good library is supposed to do.
+ *
+ * Copyright (C) 2016-2019  Ronald Huizer <rhuizer@hexpedition.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdarg.h>
+#include <inttypes.h>
+#include <yaml.h>
+#include "ds1963s-tool.h"
+#include "ds1963s-tool-yaml.h"
+
+static void
+__yaml_emitter_error(yaml_emitter_t *emitter, yaml_event_t *event)
+{
+	fprintf(stderr, "Failed to emit event %d: %s\n", event->type, emitter->problem);
+	yaml_emitter_delete(emitter);
+	exit(EXIT_FAILURE);
+}
+
+static void
+__yaml_start(yaml_emitter_t *emitter)
+{
+	yaml_event_t event;
+
+	yaml_emitter_initialize(emitter);
+	yaml_emitter_set_output_file(emitter, stdout);
+
+	yaml_stream_start_event_initialize(&event, YAML_UTF8_ENCODING);
+	if (!yaml_emitter_emit(emitter, &event))
+		__yaml_emitter_error(emitter, &event);
+
+	yaml_document_start_event_initialize(&event, NULL, NULL, NULL, 1);
+	if (!yaml_emitter_emit(emitter, &event))
+		__yaml_emitter_error(emitter, &event);
+}
+
+static void
+__yaml_end(yaml_emitter_t *emitter)
+{
+	yaml_event_t event;
+
+	yaml_document_end_event_initialize(&event, 1);
+	if (!yaml_emitter_emit(emitter, &event))
+		__yaml_emitter_error(emitter, &event);
+
+	yaml_stream_end_event_initialize(&event);
+	if (!yaml_emitter_emit(emitter, &event))
+		__yaml_emitter_error(emitter, &event);
+
+	yaml_emitter_delete(emitter);
+}
+
+static void
+__yaml_start_map(yaml_emitter_t *emitter)
+{
+	yaml_event_t event;
+
+	yaml_mapping_start_event_initialize(
+		&event,
+		NULL,
+		(yaml_char_t *)YAML_MAP_TAG,
+		1,
+		YAML_ANY_MAPPING_STYLE
+	);
+
+	if (!yaml_emitter_emit(emitter, &event))
+		__yaml_emitter_error(emitter, &event);
+}
+
+static void
+__yaml_end_map(yaml_emitter_t *emitter)
+{
+	yaml_event_t event;
+
+	yaml_mapping_end_event_initialize(&event);
+
+        if (!yaml_emitter_emit(emitter, &event))
+		__yaml_emitter_error(emitter, &event);
+}
+
+static void
+__yaml_add_tag(yaml_emitter_t *emitter, char *tag, const char *fmt, va_list ap)
+{
+	yaml_event_t event;
+	char *s;
+
+	if (vasprintf(&s, fmt, ap) == -1) {
+		perror("vasprintf()");
+		exit(EXIT_FAILURE);
+	}
+
+	yaml_scalar_event_initialize(
+		&event,
+		NULL,
+		(yaml_char_t *)tag,
+		(yaml_char_t *)s,
+		strlen(s),
+		1,
+		0,
+		YAML_PLAIN_SCALAR_STYLE
+	);
+
+	if (!yaml_emitter_emit(emitter, &event))
+		__yaml_emitter_error(emitter, &event);
+}
+
+static void
+__yaml_add_int(yaml_emitter_t *emitter, const char *fmt, ...)
+{
+	va_list ap;
+
+	va_start(ap, fmt);
+	__yaml_add_tag(emitter, YAML_INT_TAG, fmt, ap);
+	va_end(ap);
+}
+
+static void
+__yaml_add_string(yaml_emitter_t *emitter, const char *fmt, ...)
+{
+	va_list ap;
+
+	va_start(ap, fmt);
+	__yaml_add_tag(emitter, YAML_STR_TAG, fmt, ap);
+	va_end(ap);
+}
+
+void
+ds1963s_tool_rom_print_yaml(struct ds1963s_tool *tool, struct ds1963s_rom *rom)
+{
+	char buf[32];
+
+	assert(tool != NULL);
+	assert(rom != NULL);
+
+	/* rom family */
+	__yaml_add_string(&tool->emitter, "family");
+
+	snprintf(buf, sizeof buf, "0x%.2x", rom->family);
+	__yaml_add_int(&tool->emitter, buf);
+
+	/* rom serial */
+	__yaml_add_string(&tool->emitter, "serial");
+
+	for (int i = 0; i < sizeof(rom->serial); i++) {
+		snprintf(&buf[i * 2], sizeof(buf) - i * 2,
+		         "%.2x", rom->serial[i]);
+	}
+	__yaml_add_string(&tool->emitter, buf);
+
+	/* rom crc8 */
+	__yaml_add_string(&tool->emitter, "crc8");
+	snprintf(buf, sizeof buf, "0x%.2x", rom->crc);
+	__yaml_add_int(&tool->emitter, buf);
+}
+
+static void
+__write_cycle_print_yaml(yaml_emitter_t *emitter, const char *name, uint32_t value)
+{
+	__yaml_add_string(emitter, name);
+	__yaml_add_int(emitter, "0x%.8x", value);
+}
+
+void
+ds1963s_tool_write_cycle_counters_print_yaml(struct ds1963s_tool *tool, uint32_t counters[16])
+{
+	__yaml_add_string(&tool->emitter, "write_cycle_counters");
+	__yaml_start_map(&tool->emitter);
+	__write_cycle_print_yaml(&tool->emitter, "data_page_08", counters[0]);
+	__write_cycle_print_yaml(&tool->emitter, "data_page_09", counters[1]);
+	__write_cycle_print_yaml(&tool->emitter, "data_page_10", counters[2]);
+	__write_cycle_print_yaml(&tool->emitter, "data_page_11", counters[3]);
+	__write_cycle_print_yaml(&tool->emitter, "data_page_12", counters[4]);
+	__write_cycle_print_yaml(&tool->emitter, "data_page_13", counters[5]);
+	__write_cycle_print_yaml(&tool->emitter, "data_page_14", counters[6]);
+	__write_cycle_print_yaml(&tool->emitter, "data_page_15", counters[7]);
+	__write_cycle_print_yaml(&tool->emitter, "secret_0", counters[8]);
+	__write_cycle_print_yaml(&tool->emitter, "secret_1", counters[9]);
+	__write_cycle_print_yaml(&tool->emitter, "secret_2", counters[10]);
+	__write_cycle_print_yaml(&tool->emitter, "secret_3", counters[11]);
+	__write_cycle_print_yaml(&tool->emitter, "secret_4", counters[12]);
+	__write_cycle_print_yaml(&tool->emitter, "secret_5", counters[13]);
+	__write_cycle_print_yaml(&tool->emitter, "secret_6", counters[14]);
+	__write_cycle_print_yaml(&tool->emitter, "secret_7", counters[15]);
+	__yaml_end_map(&tool->emitter);
+}
+
+void ds1963s_tool_memory_dump_yaml(struct ds1963s_tool *tool)
+{
+        struct ds1963s_client *ctx = &tool->client;
+        uint8_t page[32];
+	char buf[128];
+        int i, j;
+
+	__yaml_add_string(&tool->emitter, "nvram");
+	__yaml_start_map(&tool->emitter);
+
+        for (i = 0; i < 16; i++) {
+                if (ds1963s_client_memory_read(ctx, 32 * i, page, 32) == -1)
+                        continue;
+
+		__yaml_add_string(&tool->emitter, "page_%.2d", i);
+
+                for (j = 0; j < sizeof page; j++)
+                        snprintf(buf + j * 2, sizeof(buf) - j * 2, "%.2x", page[j]);
+		__yaml_add_string(&tool->emitter, buf);
+        }
+
+	__yaml_end_map(&tool->emitter);
+}
+
+static void
+__info_yaml(struct ds1963s_tool *tool, struct ds1963s_rom *rom,
+            uint32_t counters[16])
+{
+	uint32_t prng;
+
+	ds1963s_client_rom_get(&tool->client, rom);
+	ds1963s_tool_rom_print_yaml(tool, rom);
+
+	if (ds1963s_write_cycle_get_all(&tool->client, counters) != -1)
+		ds1963s_tool_write_cycle_counters_print_yaml(tool, counters);
+
+	ds1963s_tool_memory_dump_yaml(tool);
+
+	__yaml_add_string(&tool->emitter, "prng_counter");
+	prng = ds1963s_client_prng_get(&tool->client);
+	__yaml_add_int(&tool->emitter, "0x%.8x", prng);
+}
+
+void
+ds1963s_tool_info_yaml(struct ds1963s_tool *tool)
+{
+	struct ds1963s_rom rom;
+	uint32_t counters[16];
+
+	__yaml_start(&tool->emitter);
+	__yaml_start_map(&tool->emitter);
+	__info_yaml(tool, &rom, counters);
+	__yaml_end_map(&tool->emitter);
+	__yaml_end(&tool->emitter);
+}
+
+void
+ds1963s_tool_info_full_yaml(struct ds1963s_tool *tool)
+{
+	struct ds1963s_rom rom;
+	uint32_t counters[16];
+	char buf[128];
+
+	__yaml_start(&tool->emitter);
+	__yaml_start_map(&tool->emitter);
+	__info_yaml(tool, &rom, counters);
+
+	ds1963s_tool_secrets_get(tool, &rom, counters);
+
+	__yaml_add_string(&tool->emitter, "secrets");
+	__yaml_start_map(&tool->emitter);
+        for (int secret = 0; secret < 8; secret++) {
+		__yaml_add_string(&tool->emitter, "secret_%d", secret);
+                for (int i = 0; i < 8; i++) {
+			sprintf(buf + i * 2, "%.2x",
+			        tool->brute.secrets[secret].secret[i]);
+		}
+		__yaml_add_string(&tool->emitter, buf);
+        }
+	__yaml_end_map(&tool->emitter);
+	__yaml_end_map(&tool->emitter);
+	__yaml_end(&tool->emitter);
+}

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ds1963s-tool-yaml.h
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ds1963s-tool-yaml.h
@@ -1,0 +1,41 @@
+/* ds1963s-tool-yaml.h
+ *
+ * Emit a yaml configuration defining the ds1963s ibutton dumped.
+ *
+ * Dedicated to Yuzuyu Arielle Huizer.
+ *
+ * Copyright (C) 2016-2019  Ronald Huizer <rhuizer@hexpedition.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef DS1963S_TOOL_YAML_H
+#define DS1963S_TOOL_YAML_H
+
+#include <yaml.h>
+#include "ds1963s-tool.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void ds1963s_tool_rom_print_yaml(struct ds1963s_tool *tool, struct ds1963s_rom *rom);
+void ds1963s_tool_write_cycle_counters_print_yaml(struct ds1963s_tool *tool, uint32_t counters[16]);
+void ds1963s_tool_info_yaml(struct ds1963s_tool *tool);
+void ds1963s_tool_info_full_yaml(struct ds1963s_tool *tool);
+
+#ifdef __cplusplus
+};
+#endif
+
+#endif

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ds1963s-tool.c
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ds1963s-tool.c
@@ -1,0 +1,887 @@
+/* ds1963s-tool.c
+ *
+ * A utility for accessing the DS1963S iButton over 1-wire RS-232.
+ *
+ * Dedicated to Yuzuyu Arielle Huizer.
+ *
+ * Copyright (C) 2013-2019  Ronald Huizer <rhuizer@hexpedition.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include <assert.h>
+#include <ctype.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <getopt.h>
+#include <sys/ioctl.h>
+#include "ds1963s-tool.h"
+#include "ds1963s-common.h"
+#ifdef HAVE_LIBYAML
+#include "ds1963s-tool-yaml.h"
+#endif
+
+#define DEFAULT_SERIAL_PORT		"/dev/ttyUSB0"
+#define MODE_INFO			1
+#define MODE_READ			2
+#define MODE_READ_AUTH			4
+#define MODE_WRITE			8
+#define MODE_SIGN			16
+#define MODE_WRITE_SECRET		32
+#define MODE_INFO_FULL			64
+#define MODE_SECRET_FIRST_SET		128
+#define MODE_SECRET_NEXT_SET		256
+#define MODE_VALIDATE_DATA_PAGE		512
+
+#define FORMAT_TEXT			1
+#define FORMAT_YAML			2
+
+int
+ds1963s_tool_init(struct ds1963s_tool *tool, const char *device)
+{
+	memset(tool, 0, sizeof *tool);
+	ds1963s_dev_init(&tool->brute.dev);
+	return ds1963s_client_init(&tool->client, device);
+}
+
+void
+ds1963s_tool_destroy(struct ds1963s_tool *tool)
+{
+	ds1963s_dev_destroy(&tool->brute.dev);
+	ds1963s_client_destroy(&tool->client);
+}
+
+void
+ds1963s_tool_fatal(struct ds1963s_tool *tool)
+{
+	ds1963s_tool_destroy(tool);
+	exit(EXIT_FAILURE);
+}
+
+int
+ds1963s_tool_secret_hmac_target_get(
+	struct ds1963s_tool *tool,
+	int secret,
+	int link)
+{
+	ds1963s_client_read_auth_page_reply_t auth_reply;
+	ds1963s_client_sp_read_reply_t sp_reply;
+	struct ds1963s_brute *brute;
+	int addr, ret;
+
+	assert(tool != NULL);
+	assert(secret >= 0 && secret <= 8);
+	assert(link >= 0 && link <= 3);
+
+       	brute = &tool->brute;
+	/* Only link 0 is not destructive.  The other 3 links need a partial
+	 * overwrite to make things work.
+	 */
+	if (link != 0) {
+		ret = ds1963s_client_secret_write(
+			&tool->client,		/* DS1963S context         */
+			secret,			/* Secret number           */
+			"\0\0\0\0\0\0\0\0",	/* Partial secret to write */
+			link * 2		/* Length of the secret    */
+		);
+
+		if (ret == -1)
+			return -1;
+	}
+
+	/* Calculate the address of this secret. */
+	addr = ds1963s_client_page_to_address(&tool->client, secret);
+	if (addr == -1)
+		return -1;
+
+	/* Erase the scratchpad. */
+	if (ds1963s_client_sp_erase(&tool->client, 0) == -1)
+		return -1;
+
+	/* Read auth. page over the current scratchpad/data/etc. */
+	if (ds1963s_client_read_auth(&tool->client, addr, &auth_reply) == -1)
+		return -1;
+
+	if (ds1963s_client_sp_read(&tool->client, &sp_reply) == -1)
+		return -1;
+
+	memcpy(brute->secrets[secret].target_hmac[link], &sp_reply.data[8], 20);
+	return 0;
+}
+
+void *
+ds1963s_tool_brute_link(struct ds1963s_tool *tool, int secret, int link)
+{
+	struct ds1963s_brute_secret *secret_state;
+	struct ds1963s_brute *brute;
+	struct ds1963s_device *dev;
+	int i;
+
+ 	brute = &tool->brute;
+
+	assert(brute != NULL);
+	assert(secret >= 0 && secret <= 8);
+	assert(link >= 0 && link <= 3);
+
+ 	secret_state = &brute->secrets[secret];
+	dev          = &brute->dev;
+
+	/* Set the secret to 0. */
+	memset(&dev->secret_memory[secret * 8], 0, 8);
+
+	/* Copy the known part of the secret out for this link type. */
+	memcpy(&dev->secret_memory[secret * 8 + link * 2],
+	       &secret_state->secret[link * 2],
+	       8 - link * 2);
+
+	for (i = 0; i < 65536; i++) {
+		int index = secret * 8 + link * 2;
+
+		dev->secret_memory[index]     = (i >> 0) & 0xFF;
+		dev->secret_memory[index + 1] = (i >> 8) & 0xFF;
+
+		ds1963s_dev_read_auth_page(dev, secret);
+
+		if (!memcmp(secret_state->target_hmac[link], &dev->scratchpad[8], 20)) {
+			secret_state->secret[link * 2] = (i >>  0) & 0xFF;
+			secret_state->secret[link * 2 + 1] = (i >>  8) & 0xFF;
+			break;
+		}
+
+		memset(dev->scratchpad, 0xFF, 32);
+	}
+
+	return NULL;
+}
+
+
+void
+ds1963s_tool_memory_dump_text(struct ds1963s_tool *tool)
+{
+	struct ds1963s_client *ctx = &tool->client;
+	uint8_t page[32];
+	int i, j;
+
+	for (i = 0; i < 16; i++) {
+		if (ds1963s_client_memory_read(ctx, 32 * i, page, 32) == -1)
+			continue;
+
+		printf("Page #%.2d: ", i);
+
+		for (j = 0; j < sizeof page; j++)
+			printf("%.2x", page[j]);
+		printf("\n");
+	}
+}
+
+void
+ds1963s_tool_rom_print_text(struct ds1963s_tool *tool, struct ds1963s_rom *rom)
+{
+	int i;
+
+	printf("64-BIT LASERED ROM\n");
+	printf("------------------\n");
+	printf("Family: 0x%.2x\n", rom->family);
+
+	printf("Serial: ");
+	for (i = 0; i < sizeof rom->serial; i++)
+		printf("%.2x", rom->serial[i]);
+
+	printf("\nCRC8  : 0x%.2x\n", rom->crc);
+}
+
+void
+ds1963s_tool_write_cycle_counters_print_text(struct ds1963s_tool *tool, uint32_t counters[16])
+{
+	printf("\nWrite cycle counter states\n");
+	printf("--------------------------\n");
+	printf("Data page  8: 0x%.8x\n", counters[0]);
+	printf("Data page  9: 0x%.8x\n", counters[1]);
+	printf("Data page 10: 0x%.8x\n", counters[2]);
+	printf("Data page 11: 0x%.8x\n", counters[3]);
+	printf("Data page 12: 0x%.8x\n", counters[4]);
+	printf("Data page 13: 0x%.8x\n", counters[5]);
+	printf("Data page 14: 0x%.8x\n", counters[6]);
+	printf("Data page 15: 0x%.8x\n", counters[7]);
+	printf("Secret     0: 0x%.8x\n", counters[8]);
+	printf("Secret     1: 0x%.8x\n", counters[9]);
+	printf("Secret     2: 0x%.8x\n", counters[10]);
+	printf("Secret     3: 0x%.8x\n", counters[11]);
+	printf("Secret     4: 0x%.8x\n", counters[12]);
+	printf("Secret     5: 0x%.8x\n", counters[13]);
+	printf("Secret     6: 0x%.8x\n", counters[14]);
+	printf("Secret     7: 0x%.8x\n", counters[15]);
+}
+
+void
+ds1963s_tool_info_text(struct ds1963s_tool *tool)
+{
+	struct ds1963s_rom rom;
+	uint32_t counters[16];
+
+	ds1963s_client_rom_get(&tool->client, &rom);
+	ds1963s_tool_rom_print_text(tool, &rom);
+
+	if (ds1963s_write_cycle_get_all(&tool->client, counters) != -1)
+		ds1963s_tool_write_cycle_counters_print_text(tool, counters);
+
+	printf("\n4096-bit NVRAM dump\n");
+	printf("-------------------\n");
+	ds1963s_tool_memory_dump_text(tool);
+
+	printf("\nPRNG Counter: 0x%.8x\n",
+		ds1963s_client_prng_get(&tool->client));
+}
+
+void
+ds1963s_tool_info(struct ds1963s_tool *tool, int format)
+{
+#ifdef HAVE_LIBYAML
+	if (format == FORMAT_YAML)
+		ds1963s_tool_info_yaml(tool);
+	else
+#endif
+		ds1963s_tool_info_text(tool);
+}
+
+int
+ds1963s_tool_info_full_disclaimer(void)
+{
+	int ch;
+
+	fprintf(stderr, "WARNING: This operation will perform partial "
+	                "writes to the DS1963S secrets.\n");
+	fprintf(stderr, "         Failure may cause the dongle secrets to be "
+	                "lost forever.\n\n");
+	fprintf(stderr, "Do you wish to proceed? (y/n) ");
+
+	ch = fgetc(stdin);
+	return ch == 'y' || ch == 'Y';
+}
+
+void
+xds1963s_tool_secret_hmac_target_get(
+	struct ds1963s_tool *tool,
+	int secret,
+	int link)
+{
+	int ret;
+
+	ret = ds1963s_tool_secret_hmac_target_get(tool, secret, link);
+	if (ret == -1) {
+		ds1963s_client_perror(&tool->client,
+			"ds1963s_tool_secret_hmac_target_get()");
+		ds1963s_tool_fatal(tool);
+	}
+}
+
+void
+xds1963s_client_memory_read(struct ds1963s_tool *tool,
+                            uint16_t address, uint8_t *data, size_t size)
+{
+	int ret;
+
+	ret = ds1963s_client_memory_read(&tool->client, address, data, size);
+	if (ret == -1) {
+		ds1963s_client_perror(&tool->client,
+			"ds1963s_client_memory_read()");
+		ds1963s_tool_fatal(tool);
+	}
+}
+
+void
+xds1963s_client_secret_write(struct ds1963s_tool *tool,
+                             int secret, const void *data, size_t len)
+{
+	int ret;
+
+	ret = ds1963s_client_secret_write(&tool->client, secret, data, len);
+	if (ret == -1) {
+		ds1963s_client_perror(&tool->client,
+			"ds1963s_client_secret_write()");
+		ds1963s_tool_fatal(tool);
+	}
+}
+
+void
+ds1963s_tool_secrets_get(struct ds1963s_tool *tool,
+                         struct ds1963s_rom *rom,
+                         uint32_t counters[16])
+{
+	uint8_t buf[256];
+	uint8_t data[32];
+
+	/* Initialize the brute forcer state. */
+	for (int i = 0; i < 8; i++) {
+		xds1963s_client_memory_read(
+			tool,
+			32 * i,
+			&buf[32 * i],
+			32
+		);
+	}
+
+	memcpy(tool->brute.dev.serial, &rom->raw[1], 6);
+	memcpy(tool->brute.dev.data_memory, buf, sizeof buf);
+
+	/* Initialize the write cycle counters. */
+	for (int i = 0; i < 8; i++) {
+		tool->brute.dev.data_wc[i]   = counters[i];
+		tool->brute.dev.secret_wc[i] = counters[i + 8];
+	}
+
+	if (tool->verbose)
+		fprintf(stderr, "\n01. Calculating HMAC links.\n");
+
+	for (int secret = 0; secret < 8; secret++) {
+		for (int link = 0; link < 4; link++) {
+			if (tool->verbose) {
+				fprintf(stderr, "\r    Secret #%d [%d/4]",
+				        secret, link);
+			}
+
+			xds1963s_tool_secret_hmac_target_get(tool, secret, link);
+		}
+
+		if (tool->verbose)
+			fprintf(stderr, "\r    Secret #%d [4/4]\n", secret);
+	}
+
+	if (tool->verbose)
+		fprintf(stderr, "02. Calculating secrets from HMAC links.\n");
+
+	for (int secret = 0; secret < 8; secret++) {
+		for (int link = 3; link >= 0; link--)
+			ds1963s_tool_brute_link(tool, secret, link);
+	}
+
+	if (tool->verbose) {
+		fprintf(stderr, "03. Restoring recovered keys.\n");
+		fprintf(stderr, "    Secret #0-3\n");
+	}
+
+	for (int i = 0; i < 4; i++)
+		memcpy(&data[i * 8], tool->brute.secrets[i].secret, 8);
+	xds1963s_client_secret_write(tool, 0, data, sizeof data);
+
+	if (tool->verbose)
+		fprintf(stderr, "    Secret #4-7\n");
+
+	for (int i = 0; i < 4; i++)
+		memcpy(&data[i * 8], tool->brute.secrets[i + 4].secret, 8);
+	xds1963s_client_secret_write(tool, 4, data, sizeof data);
+}
+
+void
+ds1963s_tool_info_full_text(struct ds1963s_tool *tool)
+{
+	struct ds1963s_rom rom;
+	uint32_t counters[16];
+
+	ds1963s_client_rom_get(&tool->client, &rom);
+	ds1963s_tool_rom_print_text(tool, &rom);
+
+	if (ds1963s_write_cycle_get_all(&tool->client, counters) != -1)
+		ds1963s_tool_write_cycle_counters_print_text(tool, counters);
+
+	printf("\n4096-bit NVRAM dump\n");
+	printf("-------------------\n");
+	ds1963s_tool_memory_dump_text(tool);
+
+	printf("\nPRNG Counter: 0x%.8x\n",
+		ds1963s_client_prng_get(&tool->client));
+
+	ds1963s_tool_secrets_get(tool, &rom, counters);
+
+	printf("\nSecrets dump\n");
+	printf("------------\n");
+
+	for (int secret = 0; secret < 8; secret++) {
+		printf("Secret %d: ", secret);
+		for (int i = 0; i < 8; i++)
+			printf("%.2x", tool->brute.secrets[secret].secret[i]);
+		printf("\n");
+	}
+}
+
+void
+ds1963s_tool_info_full(struct ds1963s_tool *tool, int format)
+{
+	if (ds1963s_tool_info_full_disclaimer() == 0)
+		return;
+
+#ifdef HAVE_LIBYAML
+	if (format == FORMAT_YAML)
+		ds1963s_tool_info_full_yaml(tool);
+	else
+#endif
+		ds1963s_tool_info_full_text(tool);
+}
+
+void
+ds1963s_tool_write(struct ds1963s_tool *tool, uint16_t address,
+                   const uint8_t *data, size_t len)
+{
+	struct ds1963s_client *ctx = &tool->client;
+
+	if (ds1963s_client_memory_write(ctx, address, data, len) == -1) {
+		ds1963s_client_perror(ctx, "ds1963s_client_memory_write()");
+		ds1963s_tool_fatal(tool);
+	}
+}
+
+void
+ds1963s_tool_secret_write(struct ds1963s_tool *tool, int secret,
+                          const uint8_t *data, size_t len)
+{
+	struct ds1963s_client *ctx = &tool->client;
+
+	if (ds1963s_client_secret_write(ctx, secret, data, len) == -1) {
+		ds1963s_client_perror(ctx, "ds1963s_client_secret_write()");
+		ds1963s_tool_fatal(tool);
+	}
+}
+
+void
+ds1963s_tool_secret_first_set(struct ds1963s_tool *tool, int secret, int page)
+{
+	struct ds1963s_client *ctx = &tool->client;
+	SHACopr *copr = &ctx->copr;
+	int ret;
+
+	if (secret < 0 || secret > 7) {
+		ctx->errno = DS1963S_ERROR_SECRET_NUM;
+		ds1963s_client_perror(ctx, "%s()", __FUNCTION__);
+		ds1963s_tool_fatal(tool);
+	}
+
+	/* We check if the page is valid before erasing the scratchpad. */
+	if (ds1963s_client_page_to_address(ctx, page) == -1) {
+		ds1963s_client_perror(ctx, "%s()", __FUNCTION__);
+		ds1963s_tool_fatal(tool);
+	}
+
+	/* XXX: for now we only support this with an erased scratchpad. */
+	if (ds1963s_client_sp_erase(ctx, 0) == -1) {
+		ds1963s_client_perror(ctx, "%s()", __FUNCTION__);
+		ds1963s_tool_fatal(tool);
+	}
+
+	if (ds1963s_client_secret_compute_first(ctx, page) == -1) {
+		ds1963s_client_perror(ctx, "%s()", __FUNCTION__);
+		ds1963s_tool_fatal(tool);
+	}
+
+	/* Generated secret is on scratchpad, copy it to the secret. */
+	ret = CopySecretSHA18(copr->portnum, secret);
+	if (ret == FALSE) {
+		ctx->errno = DS1963S_ERROR_COPY_SECRET;
+		ds1963s_client_perror(ctx, "%s()", __FUNCTION__);
+		ds1963s_tool_fatal(tool);
+	}
+}
+
+void
+ds1963s_tool_secret_next_set(struct ds1963s_tool *tool, int secret, int page)
+{
+	struct ds1963s_client *ctx = &tool->client;
+	SHACopr *copr = &ctx->copr;
+	int ret;
+
+	if (secret < 0 || secret > 7) {
+		ctx->errno = DS1963S_ERROR_SECRET_NUM;
+		ds1963s_client_perror(ctx, "%s()", __FUNCTION__);
+		ds1963s_tool_fatal(tool);
+	}
+
+	/* We check if the page is valid before erasing the scratchpad. */
+	if (ds1963s_client_page_to_address(ctx, page) == -1) {
+		ds1963s_client_perror(ctx, "%s()", __FUNCTION__);
+		ds1963s_tool_fatal(tool);
+	}
+
+	/* XXX: for now we only support this with an erased scratchpad. */
+	if (ds1963s_client_sp_erase(ctx, 0) == -1) {
+		ds1963s_client_perror(ctx, "%s()", __FUNCTION__);
+		ds1963s_tool_fatal(tool);
+	}
+
+	if (ds1963s_client_secret_compute_next(ctx, page) == -1) {
+		ds1963s_client_perror(ctx, "%s()", __FUNCTION__);
+		ds1963s_tool_fatal(tool);
+	}
+
+	/* Generated secret is on scratchpad, copy it to the secret. */
+	ret = CopySecretSHA18(copr->portnum, secret);
+	if (ret == FALSE) {
+		ctx->errno = DS1963S_ERROR_COPY_SECRET;
+		ds1963s_client_perror(ctx, "%s()", __FUNCTION__);
+		ds1963s_tool_fatal(tool);
+	}
+}
+
+void
+ds1963s_tool_validate_data_page(struct ds1963s_tool *tool, int page)
+{
+	struct ds1963s_client *ctx = &tool->client;
+
+	if (ds1963s_client_validate_data_page(ctx, page) == -1) {
+		ds1963s_client_perror(ctx, "%s()", __FUNCTION__);
+		ds1963s_tool_fatal(tool);
+	}
+}
+
+void
+ds1963s_tool_read(struct ds1963s_tool *tool, uint16_t address, size_t size)
+{
+	struct ds1963s_client *ctx = &tool->client;
+	uint8_t data[32];
+	size_t i;
+
+	if (ds1963s_client_sp_erase(ctx, 0) == -1) {
+		ds1963s_client_perror(ctx, "ds1963s_client_sp_erase()");
+		ds1963s_tool_fatal(tool);
+	}
+
+	/* Will not read more than 32 bytes. */
+	if (ds1963s_client_memory_read(ctx, address, data, size) == -1) {
+		ds1963s_client_perror(ctx, "ds1963s_client_memory_read()");
+		ds1963s_tool_fatal(tool);
+	}
+
+	for (i = 0; i < size; i++)
+		printf("%c", data[i]);
+}
+
+void
+ds1963s_tool_read_auth(struct ds1963s_tool *tool, int page, size_t size)
+{
+	ds1963s_client_read_auth_page_reply_t auth_reply;
+	ds1963s_client_sp_read_reply_t sp_reply;
+	struct ds1963s_client *ctx;
+	int addr;
+	int i;
+
+	assert(tool != NULL);
+
+       	ctx = &tool->client;
+	if ( (addr = ds1963s_client_page_to_address(ctx, page)) == -1) {
+		ds1963s_client_perror(ctx, "ds1963s_client_page_to_address()");
+		ds1963s_tool_fatal(tool);
+	}
+
+	if (ds1963s_client_sp_erase(ctx, 0) == -1) {
+		ds1963s_client_perror(ctx, "ds1963s_client_sp_erase()");
+		ds1963s_tool_fatal(tool);
+	}
+
+	if (ds1963s_client_read_auth(ctx, addr, &auth_reply) == -1) {
+		ds1963s_client_perror(ctx, "ds1963s_client_read_auth()");
+		ds1963s_tool_fatal(tool);
+	}
+
+	if (ds1963s_client_sp_read(ctx, &sp_reply) == -1) {
+		ds1963s_client_perror(ctx, "ds1963s_client_sp_read()");
+		ds1963s_tool_fatal(tool);
+	}
+
+	printf("Read authenticated page #%.2d\n", page);
+	printf("---------------------------\n");
+	printf("Data write cycle counter  : 0x%.8x\n", auth_reply.data_wc);
+	printf("Secret write cycle counter: 0x%.8x\n", auth_reply.secret_wc);
+	printf("CRC16                     : 0x%.4x\n", auth_reply.crc16);
+	printf("Data                      : ");
+
+	for (i = 0; i < 32; i++)
+		printf("%.2x", auth_reply.data[i]);
+	printf("\n");
+
+	printf("SHA1 hash                 : ");
+	ds1963s_client_hash_print(&sp_reply.data[8]);
+}
+
+void
+ds1963s_tool_sign(struct ds1963s_tool *tool, int page, size_t size)
+{
+	struct ds1963s_client *ctx;
+	unsigned char hash[20];
+	int addr;
+
+	assert(tool != NULL);
+
+	ctx = &tool->client;
+
+	if ( (addr = ds1963s_client_page_to_address(ctx, page)) == -1) {
+		ds1963s_client_perror(ctx, NULL);
+		ds1963s_tool_fatal(tool);
+	}
+
+	/* XXX: signing happens over scratchpad data.  We may not want
+	 * to clear this here but rather let the state persist.
+	 */
+        /* Erase the scratchpad to clear the HIDE flag. */
+	if (ds1963s_client_sp_erase(ctx, 0) == -1) {
+		ds1963s_client_perror(ctx, "ds1963s_client_sp_erase()");
+		ds1963s_tool_fatal(tool);
+	}
+
+	if (ds1963s_client_sign_data_page(ctx, addr) == -1) {
+		ds1963s_client_perror(ctx, "ds1963s_client_sign_data_page()");
+		ds1963s_tool_fatal(tool);
+	}
+
+	if (ds1963s_client_hash_read(&tool->client, hash) == -1) {
+		ds1963s_client_perror(ctx, "ds1963s_client_hash_read()");
+		ds1963s_tool_fatal(tool);
+	}
+
+	printf("Sign data page #%.2d\n", page);
+	printf("---------------------------\n");
+	printf("SHA1 hash: ");
+	ds1963s_client_hash_print(hash);
+}
+
+void
+usage(const char *progname)
+{
+	fprintf(stderr, "Usage: %s [OPTION] [DATA]\n",
+		progname ? progname : "ds1963s-tool");
+
+	fprintf(stderr, "Modifiers can be used for several commands.\n");
+	fprintf(stderr, "   -a --address=address  the memory address used "
+	                "in several functions.\n");
+	fprintf(stderr, "   -d --device=pathname  the serial device used.\n");
+	fprintf(stderr, "   -p --page=pagenum     the page number used in "
+	                "several functions.\n");
+	fprintf(stderr, "   -v --verbose          verbose operation.\n");
+
+	fprintf(stderr, "\nFunction that will be performed.\n");
+	fprintf(stderr, "   -i --info                print ibutton information.\n");
+	fprintf(stderr, "   -f --info-full           print full ibutton information.\n");
+	fprintf(stderr, "   -r --read=size           read 'size' bytes of data.\n");
+	fprintf(stderr, "   -t --read-auth=size      read 'size' bytes of "
+	                "authenticated data.\n");
+	fprintf(stderr, "   -s --sign-data=size      sign 'size' bytes of data.\n");
+	fprintf(stderr, "   -w --write=hex_data      write data.\n");
+	fprintf(stderr, "   --secret-set-first=n     compute first secret and write it to secret 'n'.\n");
+	fprintf(stderr, "   --secret-set-next=n      compute next secret and write it to secret 'n'.\n");
+	fprintf(stderr, "   --write-secret=n         write data to secret 'n'.\n");
+}
+
+static const struct option options[] =
+{
+	{ "address",		  1,	NULL,	'a' },
+	{ "device",		  1,	NULL,	'd' },
+	{ "help",		  0,	NULL,	'h' },
+	{ "page",		  1,	NULL,	'p' },
+	{ "info",		  0,	NULL,	'i' },
+	{ "info-full",		  0,	NULL,	'f' },
+	{ "read",		  1,	NULL,	'r' },
+	{ "read-auth",		  1,	NULL,	't' },
+	{ "secret-set-first",     1,    NULL,    0  },
+	{ "secret-set-next",      1,    NULL,    0  },
+	{ "sign-data",		  1,	NULL,	's' },
+	{ "validate",		  0,	NULL,	 0  },
+	{ "verbose",              0,    NULL,   'v' },
+	{ "write",		  0,	NULL,	'w' },
+	{ "write-secret",	  1,	NULL,	 0  },
+	{ NULL,			  0,	NULL,	 0  }
+};
+
+const char optstr[] = "a:d:hr:p:s:ifvwy";
+
+int
+main(int argc, char **argv)
+{
+	const char *device_name = DEFAULT_SERIAL_PORT;
+	struct ds1963s_tool tool;
+	int address, page, size;
+	int mask, mode, o;
+	uint8_t data[32];
+	int verbose;
+	size_t len;
+	int format;
+	int secret;
+	int i;
+
+	len = mode = verbose = 0;
+	format = FORMAT_TEXT;
+	address = page = secret = size = -1;
+	while ( (o = getopt_long(argc, argv, optstr, options, &i)) != -1) {
+		switch (o) {
+		case 0:
+			if (!strcmp(options[i].name, "write-secret")) {
+				mode = MODE_WRITE_SECRET;
+				secret = atoi(optarg);
+				break;
+			} else if (!strcmp(options[i].name, "secret-set-first")) {
+				mode = MODE_SECRET_FIRST_SET;
+				secret = atoi(optarg);
+				break;
+			} else if (!strcmp(options[i].name, "secret-set-next")) {
+				mode = MODE_SECRET_NEXT_SET;
+				secret = atoi(optarg);
+				break;
+			} else if (!strcmp(options[i].name, "validate")) {
+				mode = MODE_VALIDATE_DATA_PAGE;
+				break;
+			}
+			break;
+		case 'a':
+			address = atoi(optarg);
+			page = ds1963s_client_address_to_page(&tool.client, address);
+			if (page == -1) {
+				ds1963s_client_perror(&tool.client, NULL);
+				exit(EXIT_FAILURE);
+			}
+			break;
+		case 'd':
+			device_name = optarg;
+			break;
+		case 'h':
+			usage(argv[0]);
+			exit(EXIT_SUCCESS);
+		case 'r':
+			mode = MODE_READ;
+			size = atoi(optarg);
+			break;
+		case 'p':
+			page = atoi(optarg);
+			address = ds1963s_client_page_to_address(&tool.client, page);
+			if (address == -1) {
+				ds1963s_client_perror(&tool.client, NULL);
+				exit(EXIT_FAILURE);
+			}
+			break;
+		case 's':
+			mode = MODE_SIGN;
+			break;
+		case 'i':
+			mode = MODE_INFO;
+			break;
+		case 'f':
+			mode = MODE_INFO_FULL;
+			break;
+		case 't':
+			mode = MODE_READ_AUTH;
+			break;
+		case 'v':
+			verbose = 1;
+			break;
+		case 'w':
+			mode = MODE_WRITE;
+			break;
+		case 'y':
+			format = FORMAT_YAML;
+			break;
+		}
+	}
+
+	if (mode == 0) {
+		usage(argv[0]);
+		exit(EXIT_FAILURE);
+	}
+
+	/* Verify that the options we have processed make sense. */
+	mask = MODE_READ | MODE_READ_AUTH | MODE_WRITE;
+	if ( (mode & mask) != 0 && address == -1) {
+		usage(argv[0]);
+		exit(EXIT_FAILURE);
+	}
+
+	mask = MODE_SECRET_FIRST_SET;
+	if ( (mode & mask) != 0 && page == -1) {
+		fprintf(stderr, "--secret-set-first expects a -p/--page argument.\n");
+		exit(EXIT_FAILURE);
+	}
+
+       	mask = MODE_SECRET_NEXT_SET;
+	if ( (mode & mask) != 0 && page == -1) {
+		fprintf(stderr, "--secret-set-next expects a -p/--page argument.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	mask = MODE_VALIDATE_DATA_PAGE;
+	if ( (mode & mask) != 0 && page == -1) {
+		fprintf(stderr, "--validate expects a -p/--page argument.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	/* Write functions take an extra argument. */
+	mask = MODE_WRITE | MODE_WRITE_SECRET;
+	if ( (mode & mask) != 0) {
+		if (optind >= argc) {
+			usage(argv[0]);
+			exit(EXIT_FAILURE);
+		}
+
+		if (hex_decode(data, argv[optind], 32) == -1) {
+			usage(argv[0]);
+			exit(EXIT_FAILURE);
+		}
+
+		len = strlen(argv[optind]) / 2;
+	}
+
+	/* Pre-check if the serial device is accessible. */
+	if (access(device_name, R_OK | W_OK) != 0) {
+		fprintf(stderr, "Cannot access %s\n", device_name);
+		exit(EXIT_FAILURE);
+	}
+
+	/* Initialize the DS1963S device. */
+	if (ds1963s_tool_init(&tool, device_name) == -1) {
+		ds1963s_client_perror(&tool.client, "ds1963s_init()");
+		exit(EXIT_FAILURE);
+	}
+	tool.verbose = verbose;
+
+	switch (mode) {
+	case MODE_INFO:
+		ds1963s_tool_info(&tool, format);
+		break;
+	case MODE_INFO_FULL:
+		ds1963s_tool_info_full(&tool, format);
+		break;
+	case MODE_READ:
+		ds1963s_tool_read(&tool, address, size);
+		break;
+	case MODE_READ_AUTH:
+		ds1963s_tool_read_auth(&tool, page, size);
+		break;
+	case MODE_SIGN:
+		ds1963s_tool_sign(&tool, page, size);
+		break;
+	case MODE_WRITE:
+		ds1963s_tool_write(&tool, address, data, len);
+		break;
+	case MODE_WRITE_SECRET:
+		ds1963s_tool_secret_write(&tool, secret, data, len);
+		break;
+	case MODE_SECRET_FIRST_SET:
+		ds1963s_tool_secret_first_set(&tool, secret, page);
+		break;
+	case MODE_SECRET_NEXT_SET:
+		ds1963s_tool_secret_next_set(&tool, secret, page);
+		break;
+	case MODE_VALIDATE_DATA_PAGE:
+		ds1963s_tool_validate_data_page(&tool, page);
+		break;
+	}
+
+	ds1963s_tool_destroy(&tool);
+	exit(EXIT_SUCCESS);
+}

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ds1963s-tool.h
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ds1963s-tool.h
@@ -1,0 +1,54 @@
+#ifndef DS1963S_TOOL_H
+#define DS1963S_TOOL_H
+
+#include <inttypes.h>
+#include "ds1963s-client.h"
+#include "ds1963s-device.h"
+
+#ifdef HAVE_LIBYAML
+#include <yaml.h>
+#endif
+
+struct ds1963s_brute_secret
+{
+	int		state;
+	uint8_t		target_hmac[4][20];
+	uint8_t		secret[8];
+};
+
+struct ds1963s_brute
+{
+	int				log_fd;
+	struct ds1963s_device		dev;
+	struct ds1963s_brute_secret	secrets[8];
+};
+
+struct ds1963s_tool
+{
+	/* Client for communication with a DS1963S ibutton. */
+	struct ds1963s_client client;
+
+	/* Side-channel module used for dumping secrets. */
+	struct ds1963s_brute brute;
+
+	int verbose;
+
+#ifdef HAVE_LIBYAML
+	yaml_emitter_t	emitter;
+#endif
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void
+ds1963s_tool_secrets_get(struct ds1963s_tool *tool,
+                         struct ds1963s_rom *rom,
+                         uint32_t counters[16]);
+
+#ifdef __cplusplus
+};
+#endif
+
+#endif

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ds2480b-device.c
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ds2480b-device.c
@@ -1,0 +1,615 @@
+/* ds2480b-device.c
+ *
+ * A software implementation of the DS2480B serial to 1-wire driver.
+ *
+ * Dedicated to Yuzuyu Arielle Huizer.
+ *
+ * Copyright (C) 2016-2019  Ronald Huizer <rhuizer@hexpedition.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include <assert.h>
+#include <string.h>
+#include "debug.h"
+#include "ibutton/ds2480.h"
+#include "1-wire-bus.h"
+#include "ds2480b-device.h"
+#include "transport.h"
+
+#ifdef DEBUG
+
+#define NAMEDEF(x)	[x] = #x
+
+static const char * __command_names[8] = {
+	NAMEDEF(DS2480_COMMAND_SINGLE_BIT),
+	NAMEDEF(DS2480_COMMAND_SEARCH_ACCELERATOR_CONTROL),
+	NAMEDEF(DS2480_COMMAND_RESET),
+	NAMEDEF(DS2480_COMMAND_PULSE)
+};
+
+static const char * __speed_names[4] = {
+	NAMEDEF(DS2480_SPEED_REGULAR),
+	NAMEDEF(DS2480_SPEED_FLEX),
+	NAMEDEF(DS2480_SPEED_OVERDRIVE)
+};
+
+static const char * __param_code_names[8] = {
+	NAMEDEF(DS2480_PARAM_PARMREAD),
+	NAMEDEF(DS2480_PARAM_SLEW),
+	NAMEDEF(DS2480_PARAM_12VPULSE),
+	NAMEDEF(DS2480_PARAM_5VPULSE),
+	NAMEDEF(DS2480_PARAM_WRITE1LOW),
+	NAMEDEF(DS2480_PARAM_SAMPLEOFFSET),
+	NAMEDEF(DS2480_PARAM_ACTIVEPULLUPTIME),
+	NAMEDEF(DS2480_PARAM_BAUDRATE)
+};
+
+static const char *__param_value_names[8][8] = {
+	[DS2480_PARAM_SLEW] = {
+		NAMEDEF(DS2480_PARAM_SLEW_VALUE_15Vus),
+		NAMEDEF(DS2480_PARAM_SLEW_VALUE_2p2Vus),
+		NAMEDEF(DS2480_PARAM_SLEW_VALUE_1p65Vus),
+		NAMEDEF(DS2480_PARAM_SLEW_VALUE_1p37Vus),
+		NAMEDEF(DS2480_PARAM_SLEW_VALUE_1p1Vus),
+		NAMEDEF(DS2480_PARAM_SLEW_VALUE_0p83Vus),
+		NAMEDEF(DS2480_PARAM_SLEW_VALUE_0p7Vus),
+		NAMEDEF(DS2480_PARAM_SLEW_VALUE_0p55Vus)
+	},
+	[DS2480_PARAM_12VPULSE] = {
+		NAMEDEF(DS2480_PARAM_PULSE12V_VALUE_32us),
+		NAMEDEF(DS2480_PARAM_PULSE12V_VALUE_64us),
+		NAMEDEF(DS2480_PARAM_PULSE12V_VALUE_128us),
+		NAMEDEF(DS2480_PARAM_PULSE12V_VALUE_256us),
+		NAMEDEF(DS2480_PARAM_PULSE12V_VALUE_512us),
+		NAMEDEF(DS2480_PARAM_PULSE12V_VALUE_1024us),
+		NAMEDEF(DS2480_PARAM_PULSE12V_VALUE_2048us),
+		NAMEDEF(DS2480_PARAM_PULSE12V_VALUE_infinite)
+	},
+	[DS2480_PARAM_5VPULSE] = {
+		NAMEDEF(DS2480_PARAM_PULSE5V_VALUE_16p4ms),
+		NAMEDEF(DS2480_PARAM_PULSE5V_VALUE_65p5ms),
+		NAMEDEF(DS2480_PARAM_PULSE5V_VALUE_131ms),
+		NAMEDEF(DS2480_PARAM_PULSE5V_VALUE_262ms),
+		NAMEDEF(DS2480_PARAM_PULSE5V_VALUE_524ms),
+		NAMEDEF(DS2480_PARAM_PULSE5V_VALUE_1p05s),
+		NAMEDEF(DS2480_PARAM_PULSE5V_VALUE_2p10s),
+		NAMEDEF(DS2480_PARAM_PULSE5V_VALUE_infinite)
+	},
+	[DS2480_PARAM_WRITE1LOW] = {
+		NAMEDEF(DS2480_PARAM_WRITE1LOW_VALUE_8us),
+		NAMEDEF(DS2480_PARAM_WRITE1LOW_VALUE_9us),
+		NAMEDEF(DS2480_PARAM_WRITE1LOW_VALUE_10us),
+		NAMEDEF(DS2480_PARAM_WRITE1LOW_VALUE_11us),
+		NAMEDEF(DS2480_PARAM_WRITE1LOW_VALUE_12us),
+		NAMEDEF(DS2480_PARAM_WRITE1LOW_VALUE_13us),
+		NAMEDEF(DS2480_PARAM_WRITE1LOW_VALUE_14us),
+		NAMEDEF(DS2480_PARAM_WRITE1LOW_VALUE_15us)
+	},
+	[DS2480_PARAM_SAMPLEOFFSET] = {
+		NAMEDEF(DS2480_PARAM_SAMPLEOFFSET_VALUE_3us),
+		NAMEDEF(DS2480_PARAM_SAMPLEOFFSET_VALUE_4us),
+		NAMEDEF(DS2480_PARAM_SAMPLEOFFSET_VALUE_5us),
+		NAMEDEF(DS2480_PARAM_SAMPLEOFFSET_VALUE_6us),
+		NAMEDEF(DS2480_PARAM_SAMPLEOFFSET_VALUE_7us),
+		NAMEDEF(DS2480_PARAM_SAMPLEOFFSET_VALUE_8us),
+		NAMEDEF(DS2480_PARAM_SAMPLEOFFSET_VALUE_9us),
+		NAMEDEF(DS2480_PARAM_SAMPLEOFFSET_VALUE_10us)
+	},
+	[DS2480_PARAM_ACTIVEPULLUPTIME] = {
+		NAMEDEF(DS2480_PARAM_ACTIVEPULLUPTIME_VALUE_0p0us),
+		NAMEDEF(DS2480_PARAM_ACTIVEPULLUPTIME_VALUE_0p0us),
+		NAMEDEF(DS2480_PARAM_ACTIVEPULLUPTIME_VALUE_0p5us),
+		NAMEDEF(DS2480_PARAM_ACTIVEPULLUPTIME_VALUE_1p0us),
+		NAMEDEF(DS2480_PARAM_ACTIVEPULLUPTIME_VALUE_1p5us),
+		NAMEDEF(DS2480_PARAM_ACTIVEPULLUPTIME_VALUE_2p0us),
+		NAMEDEF(DS2480_PARAM_ACTIVEPULLUPTIME_VALUE_2p5us),
+		NAMEDEF(DS2480_PARAM_ACTIVEPULLUPTIME_VALUE_3p0us),
+		NAMEDEF(DS2480_PARAM_ACTIVEPULLUPTIME_VALUE_3p5us)
+	},
+	[DS2480_PARAM_BAUDRATE] = {
+		NAMEDEF(DS2480_PARAM_BAUDRATE_VALUE_9600),
+		NAMEDEF(DS2480_PARAM_BAUDRATE_VALUE_19200),
+		NAMEDEF(DS2480_PARAM_BAUDRATE_VALUE_57600),
+		NAMEDEF(DS2480_PARAM_BAUDRATE_VALUE_115200)
+	}
+};
+#endif
+
+void ds2480b_dev_init(struct ds2480b_device *dev)
+{
+	assert(dev != NULL);
+
+	dev->accelerator             = 0;
+	dev->mode                    = DS2480_MODE_INACTIVE;
+	dev->config.slew             = DS2480_PARAM_SLEW_VALUE_15Vus;
+	dev->config.pulse12v         = DS2480_PARAM_PULSE12V_VALUE_512us;
+	dev->config.pulse5v          = DS2480_PARAM_PULSE5V_VALUE_524ms;
+	dev->config.write1low        = DS2480_PARAM_WRITE1LOW_VALUE_8us;
+	dev->config.sampleoffset     = DS2480_PARAM_SAMPLEOFFSET_VALUE_8us;
+	dev->config.activepulluptime = DS2480_PARAM_ACTIVEPULLUPTIME_VALUE_3p0us;
+	dev->config.baudrate         = DS2480_PARAM_BAUDRATE_VALUE_9600;
+
+	one_wire_bus_member_init(&dev->bus_master);
+	one_wire_bus_member_master_set(&dev->bus_master);
+
+	dev->bus_master.device = (void *)dev;
+	dev->bus_master.driver = (void(*)(void *))ds2480b_dev_power_on;
+#ifdef DEBUG
+	strncpy(dev->bus_master.name, "ds2480b", sizeof dev->bus_master.name);
+#endif
+}
+
+int
+ds2480b_dev_bus_connect(struct ds2480b_device *dev, struct one_wire_bus *bus)
+{
+	if (ds2480b_dev_bus_connected(dev) != 0)
+		return -1;
+
+	return one_wire_bus_member_add(&dev->bus_master, bus);
+}
+
+int
+ds2480b_dev_bus_connected(struct ds2480b_device *dev)
+{
+	return !list_empty(&dev->bus_master.list_entry);
+}
+
+int
+ds2480b_dev_bus_rx_bit(struct ds2480b_device *dev)
+{
+	assert(dev != NULL);
+	assert(ds2480b_dev_bus_connected(dev));
+	return one_wire_bus_member_rx_bit(&dev->bus_master);
+}
+
+int
+ds2480b_dev_bus_rx_byte(struct ds2480b_device *dev)
+{
+	return one_wire_bus_member_rx_byte(&dev->bus_master);
+}
+
+int
+ds2480b_dev_bus_tx_bit(struct ds2480b_device *dev, int bit)
+{
+	assert(ds2480b_dev_bus_connected(dev));
+	return one_wire_bus_member_tx_bit(&dev->bus_master, bit);
+}
+
+int
+ds2480b_dev_bus_tx_byte(struct ds2480b_device *dev, int byte)
+{
+	return one_wire_bus_member_tx_byte(&dev->bus_master, byte);
+}
+
+void ds2480b_dev_connect_serial(struct ds2480b_device *dev, struct transport *t)
+{
+	dev->serial = t;
+}
+
+void ds2480b_dev_reset(struct ds2480b_device *dev, int speed)
+{
+	assert(dev != NULL);
+	assert(speed >= 0 && speed < 3);
+	assert(dev->mode == DS2480_MODE_COMMAND ||
+	       dev->mode == DS2480_MODE_CHECK);
+
+	dev->mode  = DS2480_MODE_COMMAND;
+	dev->speed = speed;
+
+	dev->config.slew             = DS2480_PARAM_SLEW_VALUE_15Vus;
+	dev->config.pulse12v         = DS2480_PARAM_PULSE12V_VALUE_512us;
+	dev->config.pulse5v          = DS2480_PARAM_PULSE5V_VALUE_524ms;
+	dev->config.write1low        = DS2480_PARAM_WRITE1LOW_VALUE_8us;
+	dev->config.sampleoffset     = DS2480_PARAM_SAMPLEOFFSET_VALUE_8us;
+	dev->config.activepulluptime = DS2480_PARAM_ACTIVEPULLUPTIME_VALUE_3p0us;
+	dev->config.baudrate         = DS2480_PARAM_BAUDRATE_VALUE_9600;
+}
+
+static inline int
+__ds2480b_speed_parse(int speed)
+{
+	assert(speed >= 0 && speed <= 3);
+
+	switch(speed) {
+	case 0:
+		return DS2480_SPEED_REGULAR;
+	case 1:
+		return DS2480_SPEED_FLEX;
+	case 2:
+		return DS2480_SPEED_OVERDRIVE;
+	case 3:
+		return DS2480_SPEED_REGULAR;
+	}
+
+	abort();
+}
+
+int ds2480b_dev_config_read(struct ds2480b_device *dev, int param)
+{
+	assert(dev != NULL);
+
+	switch (param) {
+	case DS2480_PARAM_SLEW:
+		return dev->config.slew;
+	case DS2480_PARAM_12VPULSE:
+		return dev->config.pulse12v;
+	case DS2480_PARAM_5VPULSE:
+		return dev->config.pulse5v;
+	case DS2480_PARAM_WRITE1LOW:
+		return dev->config.write1low;
+	case DS2480_PARAM_SAMPLEOFFSET:
+		return dev->config.sampleoffset;
+	case DS2480_PARAM_ACTIVEPULLUPTIME:
+		return dev->config.activepulluptime;
+	case DS2480_PARAM_BAUDRATE:
+		return dev->config.baudrate;
+	}
+
+	return -1;
+}
+
+int ds2480b_dev_config_write(struct ds2480b_device *dev, int param, int value)
+{
+	assert(dev != NULL);
+
+	switch (param) {
+	case DS2480_PARAM_SLEW:
+		if (value < 0 || value > 7)
+			return -1;
+
+		dev->config.slew = value;
+		break;
+	case DS2480_PARAM_12VPULSE:
+		if (value < 0 || value > 7)
+			return -1;
+
+		dev->config.pulse12v = value;
+		break;
+	case DS2480_PARAM_5VPULSE:
+		if (value < 0 || value > 7)
+			return -1;
+
+		dev->config.pulse5v = value;
+		break;
+	case DS2480_PARAM_WRITE1LOW:
+		if (value < 0 || value > 7)
+			return -1;
+
+		dev->config.write1low = value;
+		break;
+	case DS2480_PARAM_SAMPLEOFFSET:
+		if (value < 0 || value > 7)
+			return -1;
+
+		dev->config.sampleoffset = value;
+		break;
+	case DS2480_PARAM_ACTIVEPULLUPTIME:
+		if (value < 0 || value > 7)
+			return -1;
+
+		dev->config.activepulluptime = value;
+		break;
+	case DS2480_PARAM_BAUDRATE:
+		if (value < 0 || value > 3)
+			return -1;
+
+		dev->config.baudrate = value;
+		break;
+	default:
+		return -1;
+	}
+
+	return 0;
+}
+
+static int
+ds2480b_dev_command_configuration(struct ds2480b_device *dev, unsigned char byte)
+{
+	int param_code, param_value;
+	unsigned char reply;
+
+	param_code  = (byte >> 4) & 7;
+	param_value = (byte >> 1) & 7;
+
+	DEBUG_LOG("  Configuration param: %s (0x%.2x) value: %s (0x%.2x)\n",
+		__param_code_names[param_code],
+		param_code,
+		param_code == DS2480_PARAM_PARMREAD ?
+			__param_code_names[param_value] :
+			__param_value_names[param_code][param_value],
+		param_value
+	);
+
+	/* param_code is 0 for read requests, and param_value will select the
+	 * parameter to read.
+	 *
+	 * param_code will select the parameter to write otherwise, and
+	 * param_value is the value to write.
+	 */
+	if (param_code == DS2480_PARAM_PARMREAD) {
+		param_code  = param_value;
+		param_value = ds2480b_dev_config_read(dev, param_code);
+		reply = param_value << 1;
+		DEBUG_LOG("  PARMREAD: %s (0x%.2x)\n",
+			__param_value_names[param_code][param_value],
+			param_value
+		);
+	} else {
+		ds2480b_dev_config_write(dev, param_code, param_value);
+		reply = byte & ~1;
+	}
+
+	return reply;
+}
+
+static int
+ds2480b_dev_command_reset(struct ds2480b_device *dev, unsigned char byte)
+{
+	assert( (byte & 0xE3) == 0xC1);
+
+	dev->speed = __ds2480b_speed_parse( (byte >> 2) & 3);
+	DEBUG_LOG("    speed: %s (%d)\n", __speed_names[dev->speed], dev->speed);
+
+	/* XXX: bit of a hack, command reset should not reset the ds2480b
+	 * but instead generate a reset pulse.  This is just for the master
+	 * reset.
+	 */
+	ds2480b_dev_reset(dev, dev->speed);
+
+	one_wire_bus_member_reset_pulse(&dev->bus_master);
+
+	/* Reset response:
+	 * 
+	 * +-----------------------------------------------------------------+
+	 * | BIT 7 | BIT 6 | BIT 5 | BIT 4 | BIT 3 | BIT 2 | BIT 1 | BIT 0   |
+	 * +-------+-------+-------+-----------------------+-----------------+
+	 * |   1   |   1   |   X   |   0   |   1   |   1   |      state      |
+	 * +-------+-------+-------+-----------------------+-----------------+
+	 *
+	 * state 00: 1-Wire shorted
+	 *       01: presence pulse
+	 *       10: alarming presence pulse
+	 *       11: no presence pulse
+	 */
+
+	return 0xcd;
+}
+
+static int
+ds2480b_dev_command_search_accel(struct ds2480b_device *dev, unsigned char byte)
+{
+	assert(dev != NULL);
+	assert( (byte & 2) == 0);
+
+	dev->accelerator = (byte >> 4) & 1;
+	dev->speed       = __ds2480b_speed_parse( (byte >> 2) & 3);
+	DEBUG_LOG("    speed: %s (%d)\n", __speed_names[dev->speed], dev->speed);
+	DEBUG_LOG("    accel: %d\n", dev->accelerator);
+
+	/* No response. */
+	return -2;
+}
+
+static int
+ds2480b_dev_command_single_bit(struct ds2480b_device *dev, unsigned char byte)
+{
+	int bit, pullup, value;
+
+	pullup = (byte >> 1) & 1;
+	value  = (byte >> 4) & 1;
+
+	dev->speed = __ds2480b_speed_parse( (byte >> 2) & 3);
+
+	DEBUG_LOG("    speed: %s (%d)\n", __speed_names[dev->speed], dev->speed);
+	DEBUG_LOG("    value: %d pullup: %d\n", value, pullup);
+
+	bit = one_wire_bus_member_tx_bit(&dev->bus_master, value);
+
+	/* Single bit response:
+	 * 
+	 * +-----------------------------------------------------------------+
+	 * | BIT 7 | BIT 6 | BIT 5 | BIT 4 | BIT 3 | BIT 2 | BIT 1 | BIT 0   |
+	 * +-------+-------+-------+-----------------------+-----------------+
+	 * |   1   |   0   |   0   |      same as sent     | 1-wire bit (2x) |
+	 * +-------+-------+-------+-----------------------+-----------------+
+	 */
+	return (byte & 0xfc) | bit << 1 | bit;
+}
+
+static int
+ds2480b_dev_command_mode(struct ds2480b_device *dev, unsigned char byte)
+{
+	assert(dev != NULL);
+	assert(dev->mode == DS2480_MODE_COMMAND);
+
+	/* All command codes have their least significant bit set. */
+	if ( (byte & 1) == 0)
+		return -1;
+
+	/* Data mode switch. */
+	if (byte == 0xE1) {
+		DEBUG_LOG("[DS2480] MODE_COMMAND -> MODE_DATA\n");
+		dev->mode = DS2480_MODE_DATA;
+		return -2;
+	}
+
+	/* Configuration command. */
+	if ( (byte & DS2480_COMMAND_MASK) == DS2480_CONFIG)
+		return ds2480b_dev_command_configuration(dev, byte);
+
+	assert((byte & DS2480_COMMAND_MASK) == DS2480_COMMAND);
+	DEBUG_LOG("  Command: %s (%u)\n", __command_names[byte >> 5], byte >> 5);
+
+	/* Otherwise we use the top 3-bits to specify the operation. */
+	switch (byte >> 5) {
+	case DS2480_COMMAND_SINGLE_BIT:
+		return ds2480b_dev_command_single_bit(dev, byte);
+	case DS2480_COMMAND_SEARCH_ACCELERATOR_CONTROL:
+		return ds2480b_dev_command_search_accel(dev, byte);
+	case DS2480_COMMAND_RESET:
+		return ds2480b_dev_command_reset(dev, byte);
+	case DS2480_COMMAND_PULSE:
+		assert( ((byte >> 2) & 3) == 3);
+		int arm_pullup = (byte >> 1) & 1;
+		int pulse_type = (byte >> 4) & 1;
+		DEBUG_LOG("    arm_pullup: %d pulse_type: %d\n", arm_pullup, pulse_type);
+		return -1;
+	}
+
+	return -1;
+}
+
+static int
+ds2480b_dev_data_mode(struct ds2480b_device *dev, uint8_t byte, int checked)
+{
+	assert(dev != NULL);
+
+	if (checked == 0 && byte == 0xE3) {
+		DEBUG_LOG("[DS2480] MODE_DATA -> MODE_CHECK\n");
+		dev->mode = DS2480_MODE_CHECK;
+		return -2;
+	}
+
+	/* Special case; we perform the search here. */
+	if (dev->accelerator) {
+		uint8_t search[16];
+		uint8_t response[16] = {0};
+
+		/* We receive 16 bytes from serial for the search. */
+		search[0] = byte;
+		if (transport_read_all(dev->serial, &search[1], 15) == -1)
+			return -1;
+
+		for (int i = 0; i < 64; i++) {
+			int b1 = ds2480b_dev_bus_rx_bit(dev);
+			int b2 = ds2480b_dev_bus_rx_bit(dev);
+
+#if 0
+			/* Conflict */
+			if (b1 == b2) {
+				DEBUG_LOG("conflict: %d\n", b1);
+				b1 = (search[i * 2 / 8] >> (i % 8 + 1)) & 1;
+				response[i * 2 / 8] |= 1 << (i % 8);
+			}
+#endif
+
+			printf("b1: %d\n", b1);
+			response[i * 2 / 8] |= b1 << ((i * 2 % 8) + 1);
+			ds2480b_dev_bus_tx_bit(dev, b1);
+			printf("TXed rom bit #%d\n", i);
+		}
+
+		DEBUG_LOG("RESPONSE: ");
+		for (int i = 0; i < 16; i++)
+			DEBUG_LOG("%.2x", ((uint8_t *)response)[i]);
+		DEBUG_LOG("\n");
+
+		DEBUG_LOG("writing response ...\n");
+//		if (transport_write_all(dev->serial, &byte, 1) == -1)
+//			return -1;
+
+		if (transport_write_all(dev->serial, response, 16) == -1)
+			return -1;
+
+		return -2;
+	}
+
+	return ds2480b_dev_bus_tx_byte(dev, byte);
+}
+
+static int
+ds2480b_dev_check_mode(struct ds2480b_device *dev, unsigned char byte)
+{
+	assert(dev != NULL);
+
+	if (byte == 0xE3) {
+		DEBUG_LOG("[DS2480] MODE_CHECK -> MODE_DATA\n");
+		dev->mode = DS2480_MODE_DATA;
+		return ds2480b_dev_data_mode(dev, byte, 1);
+	}
+
+	/* This is a command mode request.  Switch over. */
+	DEBUG_LOG("[DS2480] MODE_CHECK -> MODE_COMMAND\n");
+	dev->mode = DS2480_MODE_COMMAND;
+	return ds2480b_dev_command_mode(dev, byte);
+}
+
+static inline int __is_reset(unsigned char byte)
+{
+	/* COMMAND RESET with 9600 speed -> 0b11000001 */
+	return (byte & 0xE3) == 0xC1;
+}
+
+int ds2480b_dev_power_on(struct ds2480b_device *dev)
+{
+	unsigned char request;
+	int response;
+
+	assert(dev != NULL);
+	assert(dev->mode == DS2480_MODE_INACTIVE);
+
+	DEBUG_LOG("[ds2480b] power on\n");
+
+	/* Handle the calibration byte. */
+	if (transport_read_all(dev->serial, &request, 1) == -1)
+		return -1;
+
+	DEBUG_LOG("    reset pulse: %.2x\n", request);
+
+	/* We expect a reset command, but will not respond. */
+	/* XXX: this is supposed to be 9600 bps.  Add check later. */
+	if (!__is_reset(request))
+		return -1;
+
+	dev->mode = DS2480_MODE_COMMAND;
+
+	while (dev->mode != DS2480_MODE_INACTIVE) {
+		if (transport_read_all(dev->serial, &request, 1) == -1)
+			return -1;
+
+		DEBUG_LOG("[ds2480b] mode: %d command: %.2x\n", dev->mode, request);
+
+		switch (dev->mode) {
+		case DS2480_MODE_COMMAND:
+			response = ds2480b_dev_command_mode(dev, request);
+			break;
+		case DS2480_MODE_DATA:
+			response = ds2480b_dev_data_mode(dev, request, 0);
+			break;
+		case DS2480_MODE_CHECK:
+			response = ds2480b_dev_check_mode(dev, request);
+			break;
+		default:
+			response = -1;
+			break;
+		}
+
+		if (response == -1)
+			return -1;
+
+		/* We have a real response, and we're still active, so we'll
+		 * reply on the bus.
+		 */
+		if (response >= 0 && dev->mode != DS2480_MODE_INACTIVE) {
+			unsigned char res = (unsigned char)response;
+
+			if (transport_write_all(dev->serial, &res, 1) == -1)
+				return -1;
+		}
+	}
+
+	abort();
+
+	return 0;
+}

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ds2480b-device.h
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ds2480b-device.h
@@ -1,0 +1,154 @@
+/* ds2480b-device.h
+ *
+ * A software implementation of the DS2480B serial to 1-wire driver.
+ *
+ * Dedicated to Yuzuyu Arielle Huizer.
+ *
+ * Copyright (C) 2016-2019  Ronald Huizer <rhuizer@hexpedition.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef DS2480_DEVICE_H
+#define DS2480_DEVICE_H
+
+#include "1-wire-bus.h"
+
+#define DS2480_COMMAND					0x81
+#define DS2480_CONFIG					0x01
+#define DS2480_COMMAND_MASK				0x81
+
+#define DS2480_MODE_INACTIVE				0
+#define DS2480_MODE_COMMAND				1
+#define DS2480_MODE_DATA				2
+#define DS2480_MODE_CHECK				3
+
+#define DS2480_SPEED_REGULAR				0
+#define DS2480_SPEED_FLEX				1
+#define DS2480_SPEED_OVERDRIVE				2
+
+#define DS2480_COMMAND_SINGLE_BIT			4
+#define DS2480_COMMAND_SEARCH_ACCELERATOR_CONTROL	5
+#define DS2480_COMMAND_RESET				6
+#define DS2480_COMMAND_PULSE				7
+
+#define DS2480_PARAM_PARMREAD				0
+#define DS2480_PARAM_SLEW				1
+#define DS2480_PARAM_12VPULSE				2
+#define DS2480_PARAM_5VPULSE				3
+#define DS2480_PARAM_WRITE1LOW				4
+#define DS2480_PARAM_SAMPLEOFFSET			5
+#define DS2480_PARAM_ACTIVEPULLUPTIME			6
+#define DS2480_PARAM_BAUDRATE				7
+
+#define DS2480_PARAM_SLEW_VALUE_15Vus			0
+#define DS2480_PARAM_SLEW_VALUE_2p2Vus			1
+#define DS2480_PARAM_SLEW_VALUE_1p65Vus			2
+#define DS2480_PARAM_SLEW_VALUE_1p37Vus			3
+#define DS2480_PARAM_SLEW_VALUE_1p1Vus			4
+#define DS2480_PARAM_SLEW_VALUE_0p83Vus			5
+#define DS2480_PARAM_SLEW_VALUE_0p7Vus			6
+#define DS2480_PARAM_SLEW_VALUE_0p55Vus			7
+
+#define DS2480_PARAM_PULSE12V_VALUE_32us		0
+#define DS2480_PARAM_PULSE12V_VALUE_64us		1
+#define DS2480_PARAM_PULSE12V_VALUE_128us		2
+#define DS2480_PARAM_PULSE12V_VALUE_256us		3
+#define DS2480_PARAM_PULSE12V_VALUE_512us		4
+#define DS2480_PARAM_PULSE12V_VALUE_1024us		5
+#define DS2480_PARAM_PULSE12V_VALUE_2048us		6
+#define DS2480_PARAM_PULSE12V_VALUE_infinite		7
+
+#define DS2480_PARAM_PULSE5V_VALUE_16p4ms		0
+#define DS2480_PARAM_PULSE5V_VALUE_65p5ms		1
+#define DS2480_PARAM_PULSE5V_VALUE_131ms		2
+#define DS2480_PARAM_PULSE5V_VALUE_262ms		3
+#define DS2480_PARAM_PULSE5V_VALUE_524ms		4
+#define DS2480_PARAM_PULSE5V_VALUE_1p05s		5
+#define DS2480_PARAM_PULSE5V_VALUE_2p10s		6
+#define DS2480_PARAM_PULSE5V_VALUE_infinite		7
+
+#define DS2480_PARAM_WRITE1LOW_VALUE_8us		0
+#define DS2480_PARAM_WRITE1LOW_VALUE_9us		1
+#define DS2480_PARAM_WRITE1LOW_VALUE_10us		2
+#define DS2480_PARAM_WRITE1LOW_VALUE_11us		3
+#define DS2480_PARAM_WRITE1LOW_VALUE_12us		4
+#define DS2480_PARAM_WRITE1LOW_VALUE_13us		5
+#define DS2480_PARAM_WRITE1LOW_VALUE_14us		6
+#define DS2480_PARAM_WRITE1LOW_VALUE_15us		7
+
+#define DS2480_PARAM_SAMPLEOFFSET_VALUE_3us		0
+#define DS2480_PARAM_SAMPLEOFFSET_VALUE_4us		1
+#define DS2480_PARAM_SAMPLEOFFSET_VALUE_5us		2
+#define DS2480_PARAM_SAMPLEOFFSET_VALUE_6us		3
+#define DS2480_PARAM_SAMPLEOFFSET_VALUE_7us		4
+#define DS2480_PARAM_SAMPLEOFFSET_VALUE_8us		5
+#define DS2480_PARAM_SAMPLEOFFSET_VALUE_9us		6
+#define DS2480_PARAM_SAMPLEOFFSET_VALUE_10us		7
+
+#define DS2480_PARAM_ACTIVEPULLUPTIME_VALUE_0p0us	0
+#define DS2480_PARAM_ACTIVEPULLUPTIME_VALUE_0p5us	1
+#define DS2480_PARAM_ACTIVEPULLUPTIME_VALUE_1p0us	2
+#define DS2480_PARAM_ACTIVEPULLUPTIME_VALUE_1p5us	3
+#define DS2480_PARAM_ACTIVEPULLUPTIME_VALUE_2p0us	4
+#define DS2480_PARAM_ACTIVEPULLUPTIME_VALUE_2p5us	5
+#define DS2480_PARAM_ACTIVEPULLUPTIME_VALUE_3p0us	6
+#define DS2480_PARAM_ACTIVEPULLUPTIME_VALUE_3p5us	7
+
+#define DS2480_PARAM_BAUDRATE_VALUE_9600		0
+#define DS2480_PARAM_BAUDRATE_VALUE_19200		1
+#define DS2480_PARAM_BAUDRATE_VALUE_57600		2
+#define DS2480_PARAM_BAUDRATE_VALUE_115200		3
+
+struct ds2480b_device_configuration
+{
+	int	slew;
+	int	pulse12v;
+	int	pulse5v;
+	int	write1low;
+	int	sampleoffset;
+	int	activepulluptime;
+	int	baudrate;
+};
+
+struct ds2480b_device
+{
+	int	accelerator;
+	int	mode;
+	int	speed;
+	struct ds2480b_device_configuration config;
+
+	/* 1-wire bus the ds2480b is the master of. */
+	struct one_wire_bus_member bus_master;
+	/* Host serial port the ds2480b communicated with. */
+	struct transport *serial;
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void ds2480b_dev_init(struct ds2480b_device *);
+int  ds2480b_dev_bus_connect(struct ds2480b_device *, struct one_wire_bus *);
+int  ds2480b_dev_bus_connected(struct ds2480b_device *);
+int  ds2480b_dev_bus_rx_bit(struct ds2480b_device *);
+int  ds2480b_dev_bus_tx_bit(struct ds2480b_device *, int);
+
+void ds2480b_dev_connect_serial(struct ds2480b_device *, struct transport *);
+int  ds2480b_dev_power_on(struct ds2480b_device *dev);
+
+#ifdef __cplusplus
+};
+#endif
+
+#endif

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/getput.h
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/getput.h
@@ -1,0 +1,159 @@
+/* getput.h
+ *
+ * Macros for integer (de)serialization.
+ *
+ * Dedicated to Yuzuyu Arielle Huizer.
+ *
+ * Copyright (C) 2007-2019  Ronald Huizer <rhuizer@hexpedition.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef GETPUT_H
+#define GETPUT_H
+
+#include <stdint.h>
+
+#define GET_FLOAT_MSB(cp)	GET_32BIT_MSB(cp)
+
+#define GET_64BIT_MSB(cp)						\
+	(((uint64_t)(uint8_t)(cp)[0] << 56) |				\
+	 ((uint64_t)(uint8_t)(cp)[1] << 48) |				\
+	 ((uint64_t)(uint8_t)(cp)[2] << 40) |				\
+	 ((uint64_t)(uint8_t)(cp)[3] << 32) |				\
+	 ((uint64_t)(uint8_t)(cp)[4] << 24) |				\
+	 ((uint64_t)(uint8_t)(cp)[5] << 16) |				\
+	 ((uint64_t)(uint8_t)(cp)[6] << 8) |				\
+	 ((uint64_t)(uint8_t)(cp)[7]))
+
+#define GET_32BIT_MSB(cp)						\
+	(((uint32_t)(uint8_t)(cp)[0] << 24) |				\
+	 ((uint32_t)(uint8_t)(cp)[1] << 16) |				\
+	 ((uint32_t)(uint8_t)(cp)[2] << 8) |				\
+	 ((uint32_t)(uint8_t)(cp)[3]))
+
+#define GET_24BIT_MSB(cp)						\
+	(((uint32_t)(uint8_t)(cp)[0] << 16) |				\
+	 ((uint32_t)(uint8_t)(cp)[1] << 8) |				\
+	 ((uint32_t)(uint8_t)(cp)[2]))
+
+#define GET_16BIT_MSB(cp)						\
+	(((uint16_t)(uint8_t)(cp)[0] << 8) |				\
+	 ((uint16_t)(uint8_t)(cp)[1]))
+
+#define PUT_FLOAT_MSB(cp, value)					\
+	PUT_32BIT_MSB(cp, *(uint32_t *)&value)
+#define PUT_DOUBLE_MSB(cp, value)					\
+	PUT_64BIT_MSB(cp, *(uint64_t *)&value)
+
+#define PUT_64BIT_MSB(cp, value)					\
+	do {								\
+		(cp)[0] = (value) >> 56;				\
+		(cp)[1] = (value) >> 48;				\
+		(cp)[2] = (value) >> 40;				\
+		(cp)[3] = (value) >> 32;				\
+		(cp)[4] = (value) >> 24;				\
+		(cp)[5] = (value) >> 16;				\
+		(cp)[6] = (value) >> 8;					\
+		(cp)[7] = (value);					\
+	} while (0)
+
+#define PUT_32BIT_MSB(cp, value)					\
+	do {								\
+		(cp)[0] = (value) >> 24;				\
+		(cp)[1] = (value) >> 16;				\
+		(cp)[2] = (value) >> 8;					\
+		(cp)[3] = (value);					\
+	} while (0)
+
+#define PUT_24BIT_MSB(cp, value)					\
+	do {								\
+		(cp)[0] = (value) >> 16;				\
+		(cp)[1] = (value) >> 8;					\
+		(cp)[2] = (value);					\
+	} while (0)
+
+#define PUT_16BIT_MSB(cp, value)					\
+	do {								\
+		(cp)[0] = (value) >> 8;					\
+		(cp)[1] = (value);					\
+	} while (0)
+
+#define GET_FLOAT_LSB(cp)	GET_32BIT_LSB(cp)
+#define GET_DOUBLE_LSB(cp)	GET_64BIT_LSB(cp)
+
+#define GET_64BIT_LSB(cp)						\
+	(((uint64_t)(uint8_t)(cp)[7] << 56) |				\
+	 ((uint64_t)(uint8_t)(cp)[6] << 48) |				\
+	 ((uint64_t)(uint8_t)(cp)[5] << 40) |				\
+	 ((uint64_t)(uint8_t)(cp)[4] << 32) |				\
+	 ((uint64_t)(uint8_t)(cp)[3] << 24) |				\
+	 ((uint64_t)(uint8_t)(cp)[2] << 16) |				\
+	 ((uint64_t)(uint8_t)(cp)[1] << 8) |				\
+	 ((uint64_t)(uint8_t)(cp)[0]))
+
+#define GET_32BIT_LSB(cp)						\
+	(((uint32_t)(uint8_t)(cp)[3] << 24) |				\
+	 ((uint32_t)(uint8_t)(cp)[2] << 16) |				\
+	 ((uint32_t)(uint8_t)(cp)[1] << 8) |				\
+	 ((uint32_t)(uint8_t)(cp)[0]))
+
+#define GET_24BIT_LSB(cp)						\
+	(((uint32_t)(uint8_t)(cp)[2] << 16) |				\
+	 ((uint32_t)(uint8_t)(cp)[1] << 8) |				\
+	 ((uint32_t)(uint8_t)(cp)[0]))
+
+#define GET_16BIT_LSB(cp)						\
+	(((uint16_t)(uint8_t)(cp)[1] << 8) |				\
+	 ((uint16_t)(uint8_t)(cp)[0]))
+
+#define PUT_FLOAT_LSB(cp, value)					\
+	PUT_32BIT_LSB(cp, *(uint32_t *)&value)
+#define PUT_DOUBLE_LSB(cp, value)					\
+	PUT_64BIT_LSB(cp, *(uint64_t *)&value)
+
+#define PUT_64BIT_LSB(cp, value)					\
+	do {								\
+		(cp)[7] = (value) >> 56;				\
+		(cp)[6] = (value) >> 48;				\
+		(cp)[5] = (value) >> 40;				\
+		(cp)[4] = (value) >> 32;				\
+		(cp)[3] = (value) >> 24;				\
+		(cp)[2] = (value) >> 16;				\
+		(cp)[1] = (value) >> 8;					\
+		(cp)[0] = (value);					\
+	} while (0)
+
+#define PUT_32BIT_LSB(cp, value)					\
+	do {								\
+		(cp)[3] = (value) >> 24;				\
+		(cp)[2] = (value) >> 16;				\
+		(cp)[1] = (value) >> 8;					\
+		(cp)[0] = (value);					\
+	} while (0)
+
+#define PUT_24BIT_LSB(cp, value)					\
+	do {								\
+		(cp)[2] = (value) >> 16;				\
+		(cp)[1] = (value) >> 8;					\
+		(cp)[0] = (value);					\
+	} while (0)
+
+#define PUT_16BIT_LSB(cp, value)					\
+	do {								\
+		(cp)[1] = (value) >> 8;					\
+		(cp)[0] = (value);					\
+	} while (0)
+
+#endif	/* !GETPUT_H */

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ibutton/CMakeLists.txt
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ibutton/CMakeLists.txt
@@ -1,0 +1,5 @@
+
+set(SOURCES crcutil.c ds2480ut.c linuxlnk.c owerr.c owllu.c ownetu.c
+            owsesu.c owtrnu.c sha18.c shaib.c)
+add_library(ibutton ${SOURCES})
+

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ibutton/crcutil.c
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ibutton/crcutil.c
@@ -1,0 +1,120 @@
+/*---------------------------------------------------------------------------
+ * Copyright (C) 2000 Dallas Semiconductor Corporation, All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY,  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL DALLAS SEMICONDUCTOR BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Except as contained in this notice, the name of Dallas Semiconductor
+ * shall not be used except as stated in the Dallas Semiconductor
+ * Branding Policy.
+ *--------------------------------------------------------------------------
+ *
+ *  crcutil.c - Keeps track of the CRC for 16 and 8 bit operations
+ *  version 2.00
+ */
+
+/* Include files */
+#include "ownet.h"
+
+/* Local global variables */
+ushort utilcrc16[MAX_PORTNUM];
+uchar utilcrc8[MAX_PORTNUM];
+static short oddparity[16] = { 0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0 };
+static uchar dscrc_table[] = {
+        0, 94,188,226, 97, 63,221,131,194,156,126, 32,163,253, 31, 65,
+      157,195, 33,127,252,162, 64, 30, 95,  1,227,189, 62, 96,130,220,
+       35,125,159,193, 66, 28,254,160,225,191, 93,  3,128,222, 60, 98,
+      190,224,  2, 92,223,129, 99, 61,124, 34,192,158, 29, 67,161,255,
+       70, 24,250,164, 39,121,155,197,132,218, 56,102,229,187, 89,  7,
+      219,133,103, 57,186,228,  6, 88, 25, 71,165,251,120, 38,196,154,
+      101, 59,217,135,  4, 90,184,230,167,249, 27, 69,198,152,122, 36,
+      248,166, 68, 26,153,199, 37,123, 58,100,134,216, 91,  5,231,185,
+      140,210, 48,110,237,179, 81, 15, 78, 16,242,172, 47,113,147,205,
+       17, 79,173,243,112, 46,204,146,211,141,111, 49,178,236, 14, 80,
+      175,241, 19, 77,206,144,114, 44,109, 51,209,143, 12, 82,176,238,
+       50,108,142,208, 83, 13,239,177,240,174, 76, 18,145,207, 45,115,
+      202,148,118, 40,171,245, 23, 73,  8, 86,180,234,105, 55,213,139,
+       87,  9,235,181, 54,104,138,212,149,203, 41,119,244,170, 72, 22,
+      233,183, 85, 11,136,214, 52,106, 43,117,151,201, 74, 20,246,168,
+      116, 42,200,150, 21, 75,169,247,182,232, 10, 84,215,137,107, 53};
+
+/*--------------------------------------------------------------------------
+ * Reset crc16 to the value passed in
+ *
+ * 'reset' - data to set crc16 to.
+ */
+void setcrc16(int portnum, ushort reset)
+{
+   utilcrc16[portnum&0x0FF] = reset;
+   return;
+}
+
+/*--------------------------------------------------------------------------
+ * Reset crc8 to the value passed in
+ *
+ * 'portnum'  - number 0 to MAX_PORTNUM-1.  This number is provided to
+ *              indicate the symbolic port number.
+ * 'reset'    - data to set crc8 to
+ */
+void setcrc8(int portnum, uchar reset)
+{
+   utilcrc8[portnum&0x0FF] = reset;
+   return;
+}
+
+/*--------------------------------------------------------------------------
+ * Calculate a new CRC16 from the input data short.  Return the current
+ * CRC16 and also update the global variable CRC16.
+ *
+ * 'portnum'  - number 0 to MAX_PORTNUM-1.  This number is provided to
+ *              indicate the symbolic port number.
+ * 'data'     - data to perform a CRC16 on
+ *
+ * Returns: the current CRC16
+ */
+ushort docrc16(int portnum, ushort cdata)
+{
+   cdata = (cdata ^ (utilcrc16[portnum&0x0FF] & 0xff)) & 0xff;
+   utilcrc16[portnum&0x0FF] >>= 8;
+
+   if (oddparity[cdata & 0xf] ^ oddparity[cdata >> 4])
+     utilcrc16[portnum&0x0FF] ^= 0xc001;
+
+   cdata <<= 6;
+   utilcrc16[portnum&0x0FF]   ^= cdata;
+   cdata <<= 1;
+   utilcrc16[portnum&0x0FF]   ^= cdata;
+
+   return utilcrc16[portnum&0x0FF];
+}
+
+/*--------------------------------------------------------------------------
+ * Update the Dallas Semiconductor One Wire CRC (utilcrc8) from the global
+ * variable utilcrc8 and the argument.
+ *
+ * 'portnum'  - number 0 to MAX_PORTNUM-1.  This number is provided to
+ *              indicate the symbolic port number.
+ * 'x'        - data byte to calculate the 8 bit crc from
+ *
+ * Returns: the updated utilcrc8.
+ */
+uchar docrc8(int portnum, uchar x)
+{
+   utilcrc8[portnum&0x0FF] = dscrc_table[utilcrc8[portnum&0x0FF] ^ x];
+   return utilcrc8[portnum&0x0FF];
+}

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ibutton/ds2480.h
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ibutton/ds2480.h
@@ -1,0 +1,206 @@
+//---------------------------------------------------------------------------
+// Copyright (C) 2000 Dallas Semiconductor Corporation, All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY,  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL DALLAS SEMICONDUCTOR BE LIABLE FOR ANY CLAIM, DAMAGES
+// OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+//
+// Except as contained in this notice, the name of Dallas Semiconductor
+// shall not be used except as stated in the Dallas Semiconductor
+// Branding Policy.
+//---------------------------------------------------------------------------
+//
+//  DS2480.H - This file contains the DS2480B constants
+//
+//  Version: 2.00
+//
+//  History: 1.02 -> 1.03 Make sure uchar is not defined twice.
+//
+//
+
+#include "ownet.h"
+
+#ifndef __MC68K__
+#include <stdlib.h>
+#ifndef _WIN32_WCE
+#include <stdio.h>
+#endif
+#endif
+
+// Mode Commands
+#define MODE_DATA                      0xE1
+#define MODE_COMMAND                   0xE3
+#define MODE_STOP_PULSE                0xF1
+
+// Return byte value
+#define RB_CHIPID_MASK                 0x1C
+#define RB_RESET_MASK                  0x03
+#define RB_1WIRESHORT                  0x00
+#define RB_PRESENCE                    0x01
+#define RB_ALARMPRESENCE               0x02
+#define RB_NOPRESENCE                  0x03
+
+#define RB_BIT_MASK                    0x03
+#define RB_BIT_ONE                     0x03
+#define RB_BIT_ZERO                    0x00
+
+// Masks for all bit ranges
+#define CMD_MASK                       0x80
+#define FUNCTSEL_MASK                  0x60
+#define BITPOL_MASK                    0x10
+#define SPEEDSEL_MASK                  0x0C
+#define MODSEL_MASK                    0x02
+#define PARMSEL_MASK                   0x70
+#define PARMSET_MASK                   0x0E
+#define VERSION_MASK                   0x1C
+
+// Command or config bit
+#define CMD_COMM                       0x81
+#define CMD_CONFIG                     0x01
+
+// Function select bits
+#define FUNCTSEL_BIT                   0x00
+#define FUNCTSEL_SEARCHON              0x30
+#define FUNCTSEL_SEARCHOFF             0x20
+#define FUNCTSEL_RESET                 0x40
+#define FUNCTSEL_CHMOD                 0x60
+
+// Bit polarity/Pulse voltage bits
+#define BITPOL_ONE                     0x10
+#define BITPOL_ZERO                    0x00
+#define BITPOL_5V                      0x00
+#define BITPOL_12V                     0x10
+
+// One Wire speed bits
+#define SPEEDSEL_STD                   0x00
+#define SPEEDSEL_FLEX                  0x04
+#define SPEEDSEL_OD                    0x08
+#define SPEEDSEL_PULSE                 0x0C
+
+// Data/Command mode select bits
+#define MODSEL_DATA                    0x00
+#define MODSEL_COMMAND                 0x02
+
+// 5V Follow Pulse select bits (If 5V pulse
+// will be following the next byte or bit.)
+#define PRIME5V_TRUE                   0x02
+#define PRIME5V_FALSE                  0x00
+
+// Parameter select bits
+#define PARMSEL_PARMREAD               0x00
+#define PARMSEL_SLEW                   0x10
+#define PARMSEL_12VPULSE               0x20
+#define PARMSEL_5VPULSE                0x30
+#define PARMSEL_WRITE1LOW              0x40
+#define PARMSEL_SAMPLEOFFSET           0x50
+#define PARMSEL_ACTIVEPULLUPTIME       0x60
+#define PARMSEL_BAUDRATE               0x70
+
+// Pull down slew rate.
+#define PARMSET_Slew15Vus              0x00
+#define PARMSET_Slew2p2Vus             0x02
+#define PARMSET_Slew1p65Vus            0x04
+#define PARMSET_Slew1p37Vus            0x06
+#define PARMSET_Slew1p1Vus             0x08
+#define PARMSET_Slew0p83Vus            0x0A
+#define PARMSET_Slew0p7Vus             0x0C
+#define PARMSET_Slew0p55Vus            0x0E
+
+// 12V programming pulse time table
+#define PARMSET_32us                   0x00
+#define PARMSET_64us                   0x02
+#define PARMSET_128us                  0x04
+#define PARMSET_256us                  0x06
+#define PARMSET_512us                  0x08
+#define PARMSET_1024us                 0x0A
+#define PARMSET_2048us                 0x0C
+#define PARMSET_infinite               0x0E
+
+// 5V strong pull up pulse time table
+#define PARMSET_16p4ms                 0x00
+#define PARMSET_65p5ms                 0x02
+#define PARMSET_131ms                  0x04
+#define PARMSET_262ms                  0x06
+#define PARMSET_524ms                  0x08
+#define PARMSET_1p05s                  0x0A
+#define PARMSET_2p10s                  0x0C
+#define PARMSET_infinite               0x0E
+
+// Write 1 low time
+#define PARMSET_Write8us               0x00
+#define PARMSET_Write9us               0x02
+#define PARMSET_Write10us              0x04
+#define PARMSET_Write11us              0x06
+#define PARMSET_Write12us              0x08
+#define PARMSET_Write13us              0x0A
+#define PARMSET_Write14us              0x0C
+#define PARMSET_Write15us              0x0E
+
+// Data sample offset and Write 0 recovery time
+#define PARMSET_SampOff3us             0x00
+#define PARMSET_SampOff4us             0x02
+#define PARMSET_SampOff5us             0x04
+#define PARMSET_SampOff6us             0x06
+#define PARMSET_SampOff7us             0x08
+#define PARMSET_SampOff8us             0x0A
+#define PARMSET_SampOff9us             0x0C
+#define PARMSET_SampOff10us            0x0E
+
+// Active pull up on time
+#define PARMSET_PullUp0p0us            0x00
+#define PARMSET_PullUp0p5us            0x02
+#define PARMSET_PullUp1p0us            0x04
+#define PARMSET_PullUp1p5us            0x06
+#define PARMSET_PullUp2p0us            0x08
+#define PARMSET_PullUp2p5us            0x0A
+#define PARMSET_PullUp3p0us            0x0C
+#define PARMSET_PullUp3p5us            0x0E
+
+// Baud rate bits
+#define PARMSET_9600                   0x00
+#define PARMSET_19200                  0x02
+#define PARMSET_57600                  0x04
+#define PARMSET_115200                 0x06
+
+// DS2480B program voltage available
+#define DS2480PROG_MASK                0x20
+
+// mode bit flags
+#define MODE_NORMAL                    0x00
+#define MODE_OVERDRIVE                 0x01
+#define MODE_STRONG5                   0x02
+#define MODE_PROGRAM                   0x04
+#define MODE_BREAK                     0x08
+
+// Versions of DS2480
+#define VER_LINK                       0x1C
+#define VER_DS2480                     0x08
+#define VER_DS2480B                    0x0C
+
+// exportable functions defined in ds2480ut.c
+SMALLINT DS2480Detect(int portnum);
+SMALLINT DS2480ChangeBaud(int portnum, uchar newbaud);
+
+// link functions from win32lnk.c or other link files
+SMALLINT  OpenCOM(int portnum, const char *port_zstr);
+int       OpenCOMEx(const char *port_zstr);
+void      CloseCOM(int portnum);
+void      FlushCOM(int portnum);
+SMALLINT  WriteCOM(int portnum, int outlen, uchar *outbuf);
+int       ReadCOM(int portnum, int inlen, uchar *inbuf);
+void      BreakCOM(int portnum);
+void      SetBaudCOM(int portnum, uchar new_baud);

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ibutton/ds2480ut.c
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ibutton/ds2480ut.c
@@ -1,0 +1,225 @@
+//---------------------------------------------------------------------------
+// Copyright (C) 2000 Dallas Semiconductor Corporation, All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY,  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL DALLAS SEMICONDUCTOR BE LIABLE FOR ANY CLAIM, DAMAGES
+// OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+//
+// Except as contained in this notice, the name of Dallas Semiconductor
+// shall not be used except as stated in the Dallas Semiconductor
+// Branding Policy.
+//---------------------------------------------------------------------------
+//
+//  ds2480ut.c - DS2480B utility functions.
+//
+//  Version: 2.01
+//
+//  History: 1.00 -> 1.01  Default PDSRC changed from 0.83 to 1.37V/us
+//                         in DS2480Detect. Changed to use msDelay instead
+//                         of Delay.
+//           1.01 -> 1.02  Changed global declarations from 'uchar' to 'int'.
+//                         Changed DSO/WORT from 7 to 10us in DS2480Detect.
+//           1.02 -> 1.03  Removed caps in #includes for Linux capatibility
+//           1.03 -> 2.00  Changed 'MLan' to 'ow'. Added support for
+//                         multiple ports.  Changed W1LT to 8us.
+//           2.00 -> 2.01 Added error handling. Added circular-include check.
+//           2.01 -> 2.10 Added raw memory error handling and SMALLINT
+//           2.10 -> 3.00 Added memory bank functionality
+//                        Added file I/O operations
+//
+
+#include "ownet.h"
+#include "ds2480.h"
+
+// global DS2480B state
+SMALLINT ULevel[MAX_PORTNUM]; // current DS2480B 1-Wire Net level
+SMALLINT UBaud[MAX_PORTNUM];  // current DS2480B baud rate
+SMALLINT UMode[MAX_PORTNUM];  // current DS2480B command or data mode state
+SMALLINT USpeed[MAX_PORTNUM]; // current DS2480B 1-Wire Net communication speed
+SMALLINT UVersion[MAX_PORTNUM]; // current DS2480B version 
+
+//---------------------------------------------------------------------------
+// Attempt to resyc and detect a DS2480B
+//
+// 'portnum'    - number 0 to MAX_PORTNUM-1.  This number was provided to
+//                OpenCOM to indicate the port number.
+//
+// Returns:  TRUE  - DS2480B detected successfully
+//           FALSE - Could not detect DS2480B
+//
+SMALLINT DS2480Detect(int portnum)
+{
+   uchar sendpacket[10],readbuffer[10];
+   uchar sendlen=0;
+
+   // reset modes
+   UMode[portnum] = MODSEL_COMMAND;
+   UBaud[portnum] = PARMSET_9600;
+   USpeed[portnum] = SPEEDSEL_FLEX;
+
+   // set the baud rate to 9600
+   SetBaudCOM(portnum,(uchar)UBaud[portnum]);
+
+   // send a break to reset the DS2480
+   BreakCOM(portnum);
+
+   // delay to let line settle
+   msDelay(2);
+
+   // flush the buffers
+   FlushCOM(portnum);
+
+   // send the timing byte
+   sendpacket[0] = 0xC1;
+   if (WriteCOM(portnum,1,sendpacket) != 1)
+   {
+      OWERROR(OWERROR_WRITECOM_FAILED);
+      return FALSE;
+   }
+
+   // delay to let line settle
+   msDelay(4);
+
+   // set the FLEX configuration parameters
+   // default PDSRC = 1.37Vus
+   sendpacket[sendlen++] = CMD_CONFIG | PARMSEL_SLEW | PARMSET_Slew1p37Vus;
+   // default W1LT = 10us
+   sendpacket[sendlen++] = CMD_CONFIG | PARMSEL_WRITE1LOW | PARMSET_Write10us;
+   // default DSO/WORT = 8us
+   sendpacket[sendlen++] = CMD_CONFIG | PARMSEL_SAMPLEOFFSET | PARMSET_SampOff8us;
+
+   // construct the command to read the baud rate (to test command block)
+   sendpacket[sendlen++] = CMD_CONFIG | PARMSEL_PARMREAD | (PARMSEL_BAUDRATE >> 3);
+
+   // also do 1 bit operation (to test 1-Wire block)
+   sendpacket[sendlen++] = CMD_COMM | FUNCTSEL_BIT | UBaud[portnum] | BITPOL_ONE;
+
+   // flush the buffers
+   FlushCOM(portnum);
+
+   // send the packet
+   if (WriteCOM(portnum,sendlen,sendpacket))
+   {
+      // read back the response
+      if (ReadCOM(portnum,5,readbuffer) == 5)
+      {
+         // look at the baud rate and bit operation
+         // to see if the response makes sense
+         if (((readbuffer[3] & 0xF1) == 0x00) &&
+             ((readbuffer[3] & 0x0E) == UBaud[portnum]) &&
+             ((readbuffer[4] & 0xF0) == 0x90) &&
+             ((readbuffer[4] & 0x0C) == UBaud[portnum]))
+            return TRUE;
+         else
+            OWERROR(OWERROR_DS2480_BAD_RESPONSE);
+      }
+      else
+         OWERROR(OWERROR_READCOM_FAILED);
+   }
+   else
+      OWERROR(OWERROR_WRITECOM_FAILED);
+
+   return FALSE;
+}
+
+//---------------------------------------------------------------------------
+// Change the DS2480B from the current baud rate to the new baud rate.
+//
+// 'portnum' - number 0 to MAX_PORTNUM-1.  This number was provided to
+//             OpenCOM to indicate the port number.
+// 'newbaud' - the new baud rate to change to, defined as:
+//               PARMSET_9600     0x00
+//               PARMSET_19200    0x02
+//               PARMSET_57600    0x04
+//               PARMSET_115200   0x06
+//
+// Returns:  current DS2480B baud rate.
+//
+SMALLINT DS2480ChangeBaud(int portnum, uchar newbaud)
+{
+   uchar rt=FALSE;
+   uchar readbuffer[5],sendpacket[5],sendpacket2[5];
+   uchar sendlen=0,sendlen2=0;
+
+   // see if diffenent then current baud rate
+   if (UBaud[portnum] == newbaud)
+      return UBaud[portnum];
+   else
+   {
+      // build the command packet
+      // check if correct mode
+      if (UMode[portnum] != MODSEL_COMMAND)
+      {
+         UMode[portnum] = MODSEL_COMMAND;
+         sendpacket[sendlen++] = MODE_COMMAND;
+      }
+      // build the command
+      sendpacket[sendlen++] = CMD_CONFIG | PARMSEL_BAUDRATE | newbaud;
+
+      // flush the buffers
+      FlushCOM(portnum);
+
+      // send the packet
+      if (!WriteCOM(portnum,sendlen,sendpacket))
+      {
+         OWERROR(OWERROR_WRITECOM_FAILED);
+         rt = FALSE;
+      }
+      else
+      {
+         // make sure buffer is flushed
+         msDelay(5);
+
+         // change our baud rate
+         SetBaudCOM(portnum,newbaud);
+         UBaud[portnum] = newbaud;
+
+         // wait for things to settle
+         msDelay(5);
+
+         // build a command packet to read back baud rate
+         sendpacket2[sendlen2++] = CMD_CONFIG | PARMSEL_PARMREAD | (PARMSEL_BAUDRATE >> 3);
+
+         // flush the buffers
+         FlushCOM(portnum);
+
+         // send the packet
+         if (WriteCOM(portnum,sendlen2,sendpacket2))
+         {
+            // read back the 1 byte response
+            if (ReadCOM(portnum,1,readbuffer) == 1)
+            {
+               // verify correct baud
+               if (((readbuffer[0] & 0x0E) == (sendpacket[sendlen-1] & 0x0E)))
+                  rt = TRUE;
+               else
+                  OWERROR(OWERROR_DS2480_WRONG_BAUD);
+            }
+            else
+               OWERROR(OWERROR_READCOM_FAILED);
+         }
+         else
+            OWERROR(OWERROR_WRITECOM_FAILED);
+      }
+   }
+
+   // if lost communication with DS2480 then reset
+   if (rt != TRUE)
+      DS2480Detect(portnum);
+
+   return UBaud[portnum];
+}

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ibutton/linuxlnk.c
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ibutton/linuxlnk.c
@@ -1,0 +1,399 @@
+//---------------------------------------------------------------------------
+// Copyright (C) 2000 Dallas Semiconductor Corporation, All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY,  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL DALLAS SEMICONDUCTOR BE LIABLE FOR ANY CLAIM, DAMAGES
+// OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+//
+// Except as contained in this notice, the name of Dallas Semiconductor
+// shall not be used except as stated in the Dallas Semiconductor
+// Branding Policy.
+//---------------------------------------------------------------------------
+//
+//  linuxlnk.C - COM functions required by MLANLL.C, MLANTRNU, MLANNETU.C and
+//           MLanFile.C for MLANU to communicate with the DS2480 based
+//           Universal Serial Adapter 'U'.  Fill in the platform specific code.
+//
+//  Version: 1.02
+//
+//  History: 1.00 -> 1.01  Added function msDelay.
+//
+//           1.01 -> 1.02  Changed to generic OpenCOM/CloseCOM for easier
+//                         use with other platforms.
+//
+
+//--------------------------------------------------------------------------
+// Copyright (C) 1998 Andrea Chambers and University of Newcastle upon Tyne,
+// All Rights Reserved.
+//--------------------------------------------------------------------------
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY,  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE UNIVERSITY OF NEWCASTLE UPON TYNE OR ANDREA CHAMBERS
+// BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH
+// THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//---------------------------------------------------------------------------
+//
+//  LinuxLNK.C - COM functions required by MLANLLU.C, MLANTRNU.C, MLANNETU.C
+//             and MLanFile.C for MLANU to communicate with the DS2480 based
+//             Universal Serial Adapter 'U'.  Platform specific code.
+//
+//  Version: 2.01
+//  History: 1.02 -> 1.03  modifications by David Smiczek
+//                         Changed to use generic OpenCOM/CloseCOM
+//                         Pass port name to OpenCOM instead of hard coded
+//                         Changed msDelay to handle long delays
+//                         Reformatted to look like 'TODO.C'
+//                         Added #include "ds2480.h" to use constants.
+//                         Added function SetBaudCOM()
+//                         Added function msGettick()
+//                         Removed delay from WriteCOM(), used tcdrain()
+//                         Added wait for byte available with timeout using
+//                          select() in ReadCOM()
+//
+//           1.03 -> 2.00  Support for multiple ports. Include "ownet.h". Use
+//                         'uchar'.  Reorder functions. Provide correct
+//                         return values to OpenCOM.  Replace 'makeraw' call.
+//                         Should now be POSIX.
+//           2.00 -> 2.01  Added support for owError library.
+//
+
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <time.h>
+#include <termios.h>
+#include <errno.h>
+#include <sys/time.h>
+
+#include "ds2480.h"
+#include "ownet.h"
+
+// LinuxLNK global
+int fd[MAX_PORTNUM];
+SMALLINT fd_init;
+struct termios origterm;
+
+
+//---------------------------------------------------------------------------
+// Attempt to open a com port.  Keep the handle in ComID.
+// Set the starting baud rate to 9600.
+//
+// 'portnum'   - number 0 to MAX_PORTNUM-1.  This number provided will
+//               be used to indicate the port number desired when calling
+//               all other functions in this library.
+//
+//
+// Returns: the port number if it was succesful otherwise -1
+//
+int OpenCOMEx(const char *port_zstr)
+{
+   int i;
+   int portnum;
+
+   if(!fd_init)
+   {
+      for(i=0; i<MAX_PORTNUM; i++)
+         fd[i] = 0;
+      fd_init = 1;
+   }
+
+   // check to find first available handle slot
+   for(portnum = 0; portnum<MAX_PORTNUM; portnum++)
+   {
+      if(!fd[portnum])
+         break;
+   }
+   OWASSERT( portnum<MAX_PORTNUM, OWERROR_PORTNUM_ERROR, -1 );
+
+   if(!OpenCOM(portnum, port_zstr))
+   {
+      return -1;
+   }
+
+   return portnum;
+}
+
+//---------------------------------------------------------------------------
+// Attempt to open a com port.
+// Set the starting baud rate to 9600.
+//
+// 'portnum'   - number 0 to MAX_PORTNUM-1.  This number provided will
+//               be used to indicate the port number desired when calling
+//               all other functions in this library.
+//
+// 'port_zstr' - zero terminate port name.  For this platform
+//               use format COMX where X is the port number.
+//
+//
+// Returns: TRUE(1)  - success, COM port opened
+//          FALSE(0) - failure, could not open specified port
+//
+SMALLINT OpenCOM(int portnum, const char *port_zstr)
+{
+   struct termios t;               // see man termios - declared as above
+   int rc;
+
+   if(!fd_init)
+   {
+      int i;
+      for(i=0; i<MAX_PORTNUM; i++)
+         fd[i] = 0;
+      fd_init = 1;
+   }
+
+   OWASSERT( portnum<MAX_PORTNUM && portnum>=0 && !fd[portnum],
+             OWERROR_PORTNUM_ERROR, FALSE );
+
+   fd[portnum] = open(port_zstr, O_RDWR);
+   if (fd[portnum]<0)
+   {
+      OWERROR(OWERROR_GET_SYSTEM_RESOURCE_FAILED);
+      return FALSE;  // changed (2.00), used to return fd;
+   }
+   rc = tcgetattr (fd[portnum], &t);
+   if (rc < 0)
+   {
+      int tmp;
+      tmp = errno;
+      close(fd[portnum]);
+      errno = tmp;
+      OWERROR(OWERROR_SYSTEM_RESOURCE_INIT_FAILED);
+      return FALSE; // changed (2.00), used to return rc;
+   }
+
+   cfsetospeed(&t, B9600);
+   cfsetispeed (&t, B9600);
+
+   // Get terminal parameters. (2.00) removed raw
+   tcgetattr(fd[portnum],&t);
+   // Save original settings.
+   origterm = t;
+
+   // Set to non-canonical mode, and no RTS/CTS handshaking
+   t.c_iflag &= ~(BRKINT|ICRNL|IGNCR|INLCR|INPCK|ISTRIP|IXON|IXOFF|PARMRK);
+   t.c_iflag |= IGNBRK|IGNPAR;
+   t.c_oflag &= ~(OPOST);
+   t.c_cflag &= ~(CRTSCTS|CSIZE|HUPCL|PARENB);
+   t.c_cflag |= (CLOCAL|CS8|CREAD);
+   t.c_lflag &= ~(ECHO|ECHOE|ECHOK|ECHONL|ICANON|IEXTEN|ISIG);
+   t.c_cc[VMIN] = 0;
+   t.c_cc[VTIME] = 3;
+
+   rc = tcsetattr(fd[portnum], TCSAFLUSH, &t);
+   tcflush(fd[portnum],TCIOFLUSH);
+
+   if (rc < 0)
+   {
+      int tmp;
+      tmp = errno;
+      close(fd[portnum]);
+      errno = tmp;
+      OWERROR(OWERROR_SYSTEM_RESOURCE_INIT_FAILED);
+      return FALSE; // changed (2.00), used to return rc;
+   }
+
+   return TRUE; // changed (2.00), used to return fd;
+}
+
+
+//---------------------------------------------------------------------------
+// Closes the connection to the port.
+//
+// 'portnum'  - number 0 to MAX_PORTNUM-1.  This number was provided to
+//              OpenCOM to indicate the port number.
+//
+void CloseCOM(int portnum)
+{
+   // restore tty settings
+   tcsetattr(fd[portnum], TCSAFLUSH, &origterm);
+   FlushCOM(portnum);
+   close(fd[portnum]);
+   fd[portnum] = 0;
+}
+
+
+//--------------------------------------------------------------------------
+// Write an array of bytes to the COM port, verify that it was
+// sent out.  Assume that baud rate has been set.
+//
+// 'portnum'   - number 0 to MAX_PORTNUM-1.  This number provided will
+//               be used to indicate the port number desired when calling
+//               all other functions in this library.
+// Returns 1 for success and 0 for failure
+//
+SMALLINT WriteCOM(int portnum, int outlen, uchar *outbuf)
+{
+   long count = outlen;
+   int i = write(fd[portnum], outbuf, outlen);
+
+   tcdrain(fd[portnum]);
+   return (i == count);
+}
+
+
+//--------------------------------------------------------------------------
+// Read an array of bytes to the COM port, verify that it was
+// sent out.  Assume that baud rate has been set.
+//
+// 'portnum'  - number 0 to MAX_PORTNUM-1.  This number was provided to
+//              OpenCOM to indicate the port number.
+// 'outlen'   - number of bytes to write to COM port
+// 'outbuf'   - pointer ot an array of bytes to write
+//
+// Returns:  TRUE(1)  - success
+//           FALSE(0) - failure
+//
+int ReadCOM(int portnum, int inlen, uchar *inbuf)
+{
+   // loop to wait until each byte is available and read it
+   for (int cnt = 0; cnt < inlen; cnt++)
+   {
+         if (read(fd[portnum],&inbuf[cnt],1) != 1)
+            return cnt;
+   }
+
+   // success, so return desired length
+   return inlen;
+}
+
+
+//---------------------------------------------------------------------------
+//  Description:
+//     flush the rx and tx buffers
+//
+// 'portnum'  - number 0 to MAX_PORTNUM-1.  This number was provided to
+//              OpenCOM to indicate the port number.
+//
+void FlushCOM(int portnum)
+{
+   tcflush(fd[portnum], TCIOFLUSH);
+}
+
+
+//--------------------------------------------------------------------------
+//  Description:
+//     Send a break on the com port for at least 2 ms
+//
+// 'portnum'  - number 0 to MAX_PORTNUM-1.  This number was provided to
+//              OpenCOM to indicate the port number.
+//
+void BreakCOM(int portnum)
+{
+   int duration = 0;              // see man termios break may be
+   tcsendbreak(fd[portnum], duration);     // too long
+}
+
+
+//--------------------------------------------------------------------------
+// Set the baud rate on the com port.
+//
+// 'portnum'   - number 0 to MAX_PORTNUM-1.  This number was provided to
+//               OpenCOM to indicate the port number.
+// 'new_baud'  - new baud rate defined as
+// PARMSET_9600     0x00
+// PARMSET_19200    0x02
+// PARMSET_57600    0x04
+// PARMSET_115200   0x06
+//
+void SetBaudCOM(int portnum, uchar new_baud)
+{
+   struct termios t;
+   speed_t baud;
+   int rc;
+
+   // read the attribute structure
+   rc = tcgetattr(fd[portnum], &t);
+   if (rc < 0)
+   {
+      close(fd[portnum]);
+      return;
+   }
+
+   // convert parameter to linux baud rate
+   switch(new_baud)
+   {
+      case PARMSET_9600:
+         baud = B9600;
+         break;
+      case PARMSET_19200:
+         baud = B19200;
+         break;
+      case PARMSET_57600:
+         baud = B57600;
+         break;
+      case PARMSET_115200:
+         baud = B115200;
+         break;
+      default:
+         baud = 0;
+   }
+
+   // set baud in structure
+   cfsetospeed(&t, baud);
+   cfsetispeed(&t, baud);
+
+   // change baud on port
+   rc = tcsetattr(fd[portnum], TCSAFLUSH, &t);
+   if (rc < 0)
+      close(fd[portnum]);
+}
+
+
+//--------------------------------------------------------------------------
+// Get the current millisecond tick count.  Does not have to represent
+// an actual time, it just needs to be an incrementing timer.
+//
+long msGettick(void)
+{
+   struct timezone tmzone;
+   struct timeval  tmval;
+   long ms;
+
+   gettimeofday(&tmval,&tmzone);
+   ms = (tmval.tv_sec & 0xFFFF) * 1000 + tmval.tv_usec / 1000;
+   return ms;
+}
+
+
+//--------------------------------------------------------------------------
+//  Description:
+//     Delay for at least 'len' ms
+//
+void msDelay(int len)
+{
+   struct timespec s;              // Set aside memory space on the stack
+
+   s.tv_sec = len / 1000;
+   s.tv_nsec = (len - (s.tv_sec * 1000)) * 1000000;
+   nanosleep(&s, NULL);
+}
+

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ibutton/owerr.c
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ibutton/owerr.c
@@ -1,0 +1,345 @@
+//---------------------------------------------------------------------------
+// Copyright (C) 2000 Dallas Semiconductor Corporation, All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY,  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL DALLAS SEMICONDUCTOR BE LIABLE FOR ANY CLAIM, DAMAGES
+// OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+//
+// Except as contained in this notice, the name of Dallas Semiconductor
+// shall not be used except as stated in the Dallas Semiconductor
+// Branding Policy.
+//---------------------------------------------------------------------------
+//
+// owerr.c - Library functions for error handling with 1-Wire library
+//
+// Version: 1.00
+//
+
+#include <string.h>
+#ifndef _WIN32_WCE
+#include <stdio.h>
+#endif
+#include "ownet.h"
+
+#ifndef SIZE_OWERROR_STACK
+   #ifdef SMALL_MEMORY_TARGET
+      //for small memory, only hole 1 error
+      #define SIZE_OWERROR_STACK 1
+   #else
+      #define SIZE_OWERROR_STACK 10
+   #endif
+#endif
+
+//---------------------------------------------------------------------------
+// Variables
+//---------------------------------------------------------------------------
+
+// Error Struct for holding error information.
+// In DEBUG, this will also hold the line number and filename.
+typedef struct
+{
+   int owErrorNum;
+#ifdef DEBUG
+   int lineno;
+   char *filename;
+#endif
+} owErrorStruct;
+
+// Ring-buffer used for stack.
+// In case of overflow, deepest error is over-written.
+static owErrorStruct owErrorStack[SIZE_OWERROR_STACK];
+
+// Stack pointer to top-most error.
+static int owErrorPointer = 0;
+
+
+//---------------------------------------------------------------------------
+// Functions Definitions
+//---------------------------------------------------------------------------
+int owGetErrorNum(void);
+void owClearError(void);
+int owHasErrors(void);
+#ifdef DEBUG
+   void owRaiseError(int,int,char*);
+#else
+   void owRaiseError(int);
+#endif
+#ifndef SMALL_MEMORY_TARGET
+   void owPrintErrorMsg(FILE *);
+   void owPrintErrorMsgStd();
+   char *owGetErrorMsg(int);
+#endif
+
+
+//--------------------------------------------------------------------------
+// The 'owGetErroNum' returns the error code of the top-most error on the
+// error stack.  NOTE: This function has the side effect of popping the
+// current error off the stack.  All successive calls to 'owGetErrorNum'
+// will further clear the error stack.
+//
+// For list of error codes, see 'ownet.h'
+//
+// Returns:   int :  The error code of the top-most error on the stack
+//
+int owGetErrorNum(void)
+{
+   int i = owErrorStack[ owErrorPointer ].owErrorNum;
+   owErrorStack[ owErrorPointer ].owErrorNum = 0;
+   if(!owErrorPointer)
+      owErrorPointer = SIZE_OWERROR_STACK - 1;
+   else
+      owErrorPointer = (owErrorPointer - 1);
+   return i;
+}
+
+//--------------------------------------------------------------------------
+// The 'owClearError' clears all the errors.
+//
+void owClearError(void)
+{
+   owErrorStack[ owErrorPointer ].owErrorNum = 0;
+}
+
+//--------------------------------------------------------------------------
+// The 'owHasErrors' is a boolean test function which tests whether or not
+// a valid error is waiting on the stack.
+//
+// Returns:   TRUE (1) : When there are errors on the stack.
+//            FALSE (0): When stack's errors are set to 0, or NO_ERROR_SET.
+//
+int owHasErrors(void)
+{
+   if(owErrorStack[ owErrorPointer ].owErrorNum)
+      return 1; //TRUE
+   else
+      return 0; //FALSE
+}
+
+#ifdef DEBUG
+   //--------------------------------------------------------------------------
+   // The 'owRaiseError' is the method for raising an error onto the error
+   // stack.
+   //
+   // Arguments:  int err - the error code you wish to raise.
+   //             int lineno - DEBUG only - the line number where it was raised
+   //             char* filename - DEBUG only - the file name where it occured.
+   //
+   void owRaiseError(int err, int lineno, char* filename)
+   {
+      owErrorPointer = (owErrorPointer + 1) % SIZE_OWERROR_STACK;
+      owErrorStack[ owErrorPointer ].owErrorNum = err;
+      owErrorStack[ owErrorPointer ].lineno = lineno;
+      owErrorStack[ owErrorPointer ].filename = filename;
+   }
+#else
+   //--------------------------------------------------------------------------
+   // The 'owRaiseError' is the method for raising an error onto the error
+   // stack.
+   //
+   // Arguments:  int err - the error code you wish to raise.
+   //
+   void owRaiseError(int err)
+   {
+      owErrorPointer = (owErrorPointer + 1) % SIZE_OWERROR_STACK;
+      owErrorStack[ owErrorPointer ].owErrorNum = err;
+   }
+#endif
+
+
+// SMALL_MEMORY_TARGET - embedded microcontrollers, where these
+// messaging functions might not make any sense.
+#ifndef SMALL_MEMORY_TARGET
+   //Array of meaningful error messages to associate with codes.
+   //Not used on targets with low memory (i.e. PIC).
+   static char *owErrorMsg[125] =
+   {
+   /*000*/ "No Error Was Set",
+   /*001*/ "No Devices found on 1-Wire Network",
+   /*002*/ "1-Wire Net Reset Failed",
+   /*003*/ "Search ROM Error: Couldn't locate next device on 1-Wire",
+   /*004*/ "Access Failed: Could not select device",
+   /*005*/ "DS2480B Adapter Not Detected",
+   /*006*/ "DS2480B: Wrong Baud",
+   /*007*/ "DS2480B: Bad Response",
+   /*008*/ "Open COM Failed",
+   /*009*/ "Write COM Failed",
+   /*010*/ "Read COM Failed",
+   /*011*/ "Data Block Too Large",
+   /*012*/ "Block Transfer failed",
+   /*013*/ "Program Pulse Failed",
+   /*014*/ "Program Byte Failed",
+   /*015*/ "Write Byte Failed",
+   /*016*/ "Read Byte Failed",
+   /*017*/ "Write Verify Failed",
+   /*018*/ "Read Verify Failed",
+   /*019*/ "Write Scratchpad Failed",
+   /*020*/ "Copy Scratchpad Failed",
+   /*021*/ "Incorrect CRC Length",
+   /*022*/ "CRC Failed",
+   /*023*/ "Failed to acquire a necessary system resource",
+   /*024*/ "Failed to initialize system resource",
+   /*025*/ "Data too long to fit on specified device.",
+   /*026*/ "Read exceeds memory bank end.",
+   /*027*/ "Write exceeds memory bank end.",
+   /*028*/ "Device select failed",
+   /*029*/ "Read Scratch Pad verify failed.",
+   /*030*/ "Copy scratchpad complete not found",
+   /*031*/ "Erase scratchpad complete not found",
+   /*032*/ "Address read back from scrachpad was incorrect",
+   /*033*/ "Read page with extra-info not supported by this memory bank",
+   /*034*/ "Read page packet with extra-info not supported by this memory bank",
+   /*035*/ "Length of packet requested exceeds page size",
+   /*036*/ "Invalid length in packet",
+   /*037*/ "Program pulse required but not available",
+   /*038*/ "Trying to access a read-only memory bank",
+   /*039*/ "Current bank is not general purpose memory",
+   /*040*/ "Read back from write compare is incorrect, page may be locked",
+   /*041*/ "Invalid page number for this memory bank",
+   /*042*/ "Read page with CRC not supported by this memory bank",
+   /*043*/ "Read page with CRC and extra-info not supported by this memory bank",
+   /*044*/ "Read back from write incorrect, could not lock page",
+   /*045*/ "Read back from write incorrect, could not lock redirect byte",
+   /*046*/ "The read of the status was not completed.",
+   /*047*/ "Page redirection not supported by this memory bank",
+   /*048*/ "Lock Page redirection not supported by this memory bank",
+   /*049*/ "Read back byte on EPROM programming did not match.",
+   /*050*/ "Can not write to a page that is locked.",
+   /*051*/ "Can not lock a redirected page that has already been locked.",
+   /*052*/ "Trying to redirect a locked redirected page.",
+   /*053*/ "Trying to lock a page that is already locked.",
+   /*054*/ "Trying to write to a memory bank that is write protected.",
+   /*055*/ "Error due to not matching MAC.",
+   /*056*/ "Memory Bank is write protected.",
+   /*057*/ "Secret is write protected, can not Load First Secret.",
+   /*058*/ "Error in Reading Scratchpad after Computing Next Secret.",
+   /*059*/ "Load Error from Loading First Secret.",
+   /*060*/ "Power delivery required but not available",
+   /*061*/ "Not a valid file name.",
+   /*062*/ "Unable to Create a Directory in this part.",
+   /*063*/ "That file already exists.",
+   /*064*/ "The directory is not empty.",
+   /*065*/ "The wrong type of part for this operation.",
+   /*066*/ "The max len for this file is too small.",
+   /*067*/ "This is not a write once bank.",
+   /*068*/ "The file can not be found.",
+   /*069*/ "There is not enough space available.",
+   /*070*/ "There is not a page to match that bit in the bitmap.",
+   /*071*/ "There are no jobs for EPROM parts.",
+   /*072*/ "Function not supported to modify attributes.",
+   /*073*/ "Handle is not in use.",
+   /*074*/ "Tring to read a write only file.",
+   /*075*/ "There is no handle available for use.",
+   /*076*/ "The directory provided is an invalid directory.",
+   /*077*/ "Handle does not exist.",
+   /*078*/ "Serial Number did not match with current job.",
+   /*079*/ "Can not program EPROM because a non-EPROM part on the network.",
+   /*080*/ "Write protect redirection byte is set.",
+   /*081*/ "There is an inappropriate directory length.",
+   /*082*/ "The file has already been terminated.",
+   /*083*/ "Failed to read memory page of iButton part.",
+   /*084*/ "Failed to match scratchpad of iButton part.",
+   /*085*/ "Failed to erase scratchpad of iButton part.",
+   /*086*/ "Failed to read scratchpad of iButton part.",
+   /*087*/ "Failed to execute SHA function on SHA iButton.",
+   /*088*/ "SHA iButton did not return a status completion byte.",
+   /*089*/ "Write data page failed.",
+   /*090*/ "Copy secret into secret memory pages failed.",
+   /*091*/ "Bind unique secret to iButton failed.",
+   /*092*/ "Could not install secret into user token.",
+   /*093*/ "Transaction Incomplete: signature did not match.",
+   /*094*/ "Transaction Incomplete: could not sign service data.",
+   /*095*/ "User token did not provide a valid authentication response.",
+   /*096*/ "Failed to answer a challenge on the user token.",
+   /*097*/ "Failed to create a challenge on the coprocessor.",
+   /*098*/ "Transaction Incomplete: service data was not valid.",
+   /*099*/ "Transaction Incomplete: service data was not updated.",
+   /*100*/ "Unrecoverable, catastrophic service failure occured.",
+   /*101*/ "Load First Secret from scratchpad data failed.",
+   /*102*/ "Failed to match signature of user's service data.",
+   /*103*/ "Subkey out of range for the DS1991.",
+   /*104*/ "Block ID out of range for the DS1991",
+   /*105*/ "Password is enabled",
+   /*106*/ "Password is invalid",
+   /*107*/ "This memory bank has no read only password",
+   /*108*/ "This memory bank has no read/write password",
+   /*109*/ "1-Wire is shorted",
+   /*110*/ "Error communicating with 1-Wire adapter",
+   /*111*/ "CopyScratchpad failed: Ending Offset must go to end of page",
+   /*112*/ "WriteScratchpad failed: Ending Offset must go to end of page",
+   /*113*/ "Mission can not be stopped while one is not in progress",
+   /*114*/ "Error stopping the mission",
+   /*115*/ "Port number is outside (0,MAX_PORTNUM) interval",
+   /*116*/ "Level of the 1-Wire was not changed",
+   /*117*/ "Both the Read Only and Read Write Passwords must be set",
+   /*118*/ "Failure to change latch state."
+   /*119*/ "Could not open usb port through libusb",
+   /*120*/ "Libusb DS2490 port already opened",
+   /*121*/ "Failed to set libusb configuration",
+   /*122*/ "Failed to claim libusb interface",
+   /*123*/ "Failed to set libusb altinterface",
+   /*124*/ "No adapter found at this port number"
+   };
+
+   char *owGetErrorMsg(int err)
+   {
+      return owErrorMsg[err];
+   }
+
+#ifndef __C51__
+   //--------------------------------------------------------------------------
+   // The 'owPrintErrorMsg' is the method for printing an error from the stack.
+   // The destination for the print is specified by the argument, fileno, which
+   // can be stderr, stdout, or a log file.  In non-debug mode, the output is
+   // of the form:
+   // Error num: Error msg
+   //
+   // In debug-mode, the output is of the form:
+   // Error num: filename line#: Error msg
+   //
+   // NOTE: This function has the side-effect of popping the error off the stack.
+   //
+   // Arguments:  FILE*: the destination for printing.
+   //
+   void owPrintErrorMsg(FILE *filenum)
+   {
+   #ifdef DEBUG
+      int l = owErrorStack[ owErrorPointer ].lineno;
+      char *f = owErrorStack[ owErrorPointer ].filename;
+      int err = owGetErrorNum();
+      fprintf(filenum,"Error %d: %s line %d: %s\r\n",err,f,l,owErrorMsg[err]);
+   #else
+      int err = owGetErrorNum();
+      fprintf(filenum,"Error %d: %s\r\n",err,owErrorMsg[err]);
+   #endif
+   }
+#endif //__C51__
+
+   // Same as above, except uses default printf output
+   void owPrintErrorMsgStd()
+   {
+   #ifdef DEBUG
+      int l = owErrorStack[ owErrorPointer ].lineno;
+      char *f = owErrorStack[ owErrorPointer ].filename;
+      int err = owGetErrorNum();
+      printf("Error %d: %s line %d: %s\r\n",err,f,l,owErrorMsg[err]);
+   #else
+      int err = owGetErrorNum();
+      printf("Error %d: %s\r\n",err,owErrorMsg[err]);
+   #endif
+   }
+#endif
+

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ibutton/owfile.h
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ibutton/owfile.h
@@ -1,0 +1,196 @@
+/*---------------------------------------------------------------------------
+ * Copyright (C) 2000 Dallas Semiconductor Corporation, All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY,  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL DALLAS SEMICONDUCTOR BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Except as contained in this notice, the name of Dallas Semiconductor
+ * shall not be used except as stated in the Dallas Semiconductor
+ * Branding Policy.
+ *--------------------------------------------------------------------------
+ *
+ *  owFile.h - Contains the types and constants for file I/O. 
+ *
+ *  version 1.00
+ */
+
+#include "ownet.h"
+
+#ifndef OWFILE_H
+#define OWFILE_H
+#define MAX_NUM_PGS   256    /* this is for max pages part might have */
+                             /* increase if you are going to use parts */
+                             /* with more than 256 pages. */
+#define PAGE_TYPE     uchar  /* change if the page number can be > 256 */
+#define FILE_NAME_LEN 7      /* the length of a new file */
+#define FIRST_FOUND   204    /*  don't know how many now so return max */
+/* Used in internal function Read_Page and page cache */
+#define STATUSMEM     0x80
+#define REDIRMEM      0x40
+#define REGMEM        0 
+#define DEPTH         254
+#define CACHE_TIMEOUT 8000
+/* Directory options */
+#define SET_DIR            0
+#define READ_DIR           1
+/* program Job constants */
+#define PJOB_NONE               0
+#define PJOB_WRITE              1
+#define PJOB_REDIR              2
+#define PJOB_ADD                3
+#define PJOB_TERM               4
+#define PJOB_START              0x80   
+#define PJOB_MASK               0x7F
+#define APPEND                  1
+
+/* external file information structure */
+typedef struct 
+{
+   uchar Name[4];          /*  4 */
+   uchar Ext;              /*  1 */
+   uchar Spage;            /*  1 */
+   uchar NumPgs;           /*  1 */
+   uchar Attrib;           /*  1 */
+   uchar BM[32];           /* 32 */
+} FileEntry;
+
+/* structure use when reading or changing the current directory */
+typedef struct
+{
+   uchar NumEntries;      /* number of entries in path 0-10 */
+   char  Ref;             /* reference character '\' or '.'  */
+   char  Entries[10][4];  /* sub-directory entry names */                                  
+} DirectoryPath;
+
+/* internal file information structure */
+typedef struct 
+{
+   uchar Name[4];          /* 4  File/Directory name                         */
+   uchar Ext;              /* 1  File/Directory extension                    */
+   uchar Spage;            /* 1  Start page                                  */
+   uchar NumPgs;           /* 1  Number of pages                             */
+   uchar Attrib;           /* 1  Attribute 0x01 for readonly 0x02 for hidden */
+   uchar Dpage;            /* 1  Directory page this entry is in             */
+   uchar Offset;           /* 1  Byte offset into directory page of entry    */
+   uchar Read;             /* 1  Read = 1 if opened and 0 if created         */
+   uchar PDpage;           /* 1  Previous directory page number              */
+} FileInfo;
+
+/* current directory structure */
+typedef struct 
+{
+   uchar ne;          /* number of entries                        */
+   struct {
+      uchar name[4];  /* name and extention of the sub-directory  */
+      PAGE_TYPE page; /* page the subdirectory starts on          */
+      uchar attrib;   /* attribute of the directory               */
+   } Entry [10];
+   uchar DRom[8];     /* rom that this directory is valid for     */
+} CurrentDirectory;  
+
+/* structure to hold the program job list ~ 7977 bytes */
+typedef struct
+{                    
+   uchar ERom[8];          /* rom of the program job target                  */
+   uchar EBitmap[32];      /* bit map kept for                               */
+   uchar OrgBitmap[32];    /* original bitmap                                */
+   struct {
+      uchar     wr;        /* flag to indicate this page needs to be written */
+      PAGE_TYPE len;       /* length of data                                 */
+      uchar     data[29];  /* data to write                                  */
+      uchar     bm[4];     /* bitmap for bytes to write                      */
+   } Page[MAX_NUM_PGS];    /* 256 possible jobs                              */
+} ProgramJob;   
+
+/* type to hold a data entry in the DHash */
+typedef struct
+{
+   uchar     ROM[8];        /* rom of device page is from              */
+   ulong     Tstamp;        /* time stamp when page void               */
+   uchar     Fptr;          /* forward pointer to next entry in chain  */
+   uchar     Bptr;          /* back pointer to previous entry in chain */
+   uchar     Hptr;          /* hash pointer to hash position           */
+   PAGE_TYPE Page;          /* page number                             */
+   uchar     Data[32];      /* page data including length              */
+   uchar     Redir;         /* redirection page                        */
+}  Dentry;
+#endif /* OWFILE_H */
+
+/* function prototypes for owcache.c */
+void     InitDHash(void);  
+uchar    AddPage(int portnum, uchar *SNum, PAGE_TYPE pg, uchar *buf, int len);        
+SMALLINT FindPage(int portnum, uchar *SNum, PAGE_TYPE *page, uchar mflag, uchar time, 
+                  uchar *buf, int *len, uchar *space_num);
+uchar FreePage(uchar ptr);
+
+/* function prototypes for owfile.c */
+SMALLINT      owFirstFile(int, uchar *, FileEntry *); 
+SMALLINT      owNextFile(int, uchar *, FileEntry *);
+SMALLINT      owOpenFile(int, uchar *, FileEntry *,short *);
+SMALLINT      owCreateFile(int, uchar *, int *, short *, FileEntry *);
+SMALLINT      owCloseFile(int, uchar *, short);
+SMALLINT      owReadFile(int, uchar *, short, uchar *, int,int *);
+SMALLINT      owRemoveDir(int, uchar *, FileEntry *);
+SMALLINT      owWriteFile(int, uchar *, short , uchar *, int );
+SMALLINT      owDeleteFile(int, uchar *, FileEntry *);
+SMALLINT      owFormat(int, uchar *);
+SMALLINT      owAttribute(int, uchar *, short, FileEntry *);
+SMALLINT      owReNameFile(int, uchar *, short, FileEntry *); 
+SMALLINT      owChangeDirectory(int, uchar *, DirectoryPath *); 
+SMALLINT      owCreateDir(int, uchar *, FileEntry *);
+DirectoryPath owGetCurrentDir(int, uchar *);
+SMALLINT      owWriteAddFile(int,uchar *,short,short,short,uchar *,int *);
+SMALLINT      owTerminateAddFile(int,uchar *,FileEntry *);
+SMALLINT      ReadBitMap(int, uchar *, uchar *);
+SMALLINT      WriteBitMap(int, uchar *, uchar *);
+SMALLINT      ReadNumEntry(int, uchar *, short , FileEntry *,
+                           PAGE_TYPE *);
+SMALLINT      GetMaxWrite(int, uchar *, uchar *);
+SMALLINT      FindDirectoryInfo(int, uchar *, PAGE_TYPE *, FileInfo *); 
+SMALLINT      ValidRom(int, uchar *);  
+SMALLINT      BitMapChange(int, uchar *, uchar, uchar, uchar *);
+SMALLINT      Valid_FileName(FileEntry *);
+void          FindEmpties(int, uchar *, uchar *, PAGE_TYPE *, 
+                          PAGE_TYPE *);
+int           maxPages(int, uchar *);
+void          ChangeRom(int portnum, uchar *SNum);
+PAGE_TYPE     getLastPage(int, uchar *);
+
+/* function prototypes for owpgrw.c */
+SMALLINT Read_Page(int portnum, uchar *SNum, uchar *buff, uchar flag, 
+                   PAGE_TYPE *pg, int *len);
+SMALLINT Write_Page(int portnum, uchar *SNum, uchar *buff, PAGE_TYPE page, int len);
+SMALLINT ExtWrite(int portnum, uchar *SNum, uchar strt_page, uchar *file, int fllen,
+                  uchar *BM);
+SMALLINT ExtRead(int portnum, uchar *SNum, uchar *file, int start_page, 
+						int maxlen, uchar del, uchar *BM, int *fl_len);
+SMALLINT ExtendedRead_Page(int portnum, uchar *SNum, uchar *buff, PAGE_TYPE pg);
+
+/* function prototypes for owprgm.c */
+SMALLINT owCreateProgramJob(int, uchar *); 
+SMALLINT owDoProgramJob(int, uchar *); 
+SMALLINT isJob(int,uchar *);
+SMALLINT isJobWritten(int,uchar *,PAGE_TYPE);
+SMALLINT getJobData(int,uchar *,PAGE_TYPE,uchar *,int *);
+SMALLINT setJobData(int,uchar *,PAGE_TYPE,uchar *,int);
+SMALLINT setJobWritten(int,uchar *,PAGE_TYPE,SMALLINT);
+SMALLINT getOrigBM(int,uchar *,uchar *);
+SMALLINT setProgramJob(int,uchar *,uchar,int);
+SMALLINT getProgramJob(int,uchar *,uchar *,int);
+SMALLINT WriteJobByte(int, uchar *, PAGE_TYPE, short, uchar, short);
+SMALLINT TerminatePage(int, uchar *, short, uchar *);

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ibutton/owllu.c
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ibutton/owllu.c
@@ -1,0 +1,831 @@
+//---------------------------------------------------------------------------
+// Copyright (C) 2000 Dallas Semiconductor Corporation, All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY,  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL DALLAS SEMICONDUCTOR BE LIABLE FOR ANY CLAIM, DAMAGES
+// OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+//
+// Except as contained in this notice, the name of Dallas Semiconductor
+// shall not be used except as stated in the Dallas Semiconductor
+// Branding Policy.
+//---------------------------------------------------------------------------
+//
+//  owLLU.C - Link Layer 1-Wire Net functions using the DS2480/DS2480B (U)
+//            serial interface chip.
+//
+//  Version: 3.00
+//
+//  History: 1.00 -> 1.01  DS2480 version number now ignored in
+//                         owTouchReset.
+//           1.02 -> 1.03  Removed caps in #includes for Linux capatibility
+//                         Removed #include <windows.h>
+//                         Add #include "ownet.h" to define TRUE,FALSE
+//           1.03 -> 2.00  Changed 'MLan' to 'ow'. Added support for
+//                         multiple ports.
+//           2.00 -> 2.01 Added error handling. Added circular-include check.
+//           2.01 -> 2.10 Added raw memory error handling and SMALLINT
+//           2.10 -> 3.00 Added memory bank functionality
+//                        Added file I/O operations
+//                        Added owReadBitPower and owWriteBytePower
+//                        Added support for THE LINK
+//                        Updated owLevel to match AN192
+//
+
+#include "ownet.h"
+#include "ds2480.h"
+
+int dodebug=0;
+
+// external globals
+extern SMALLINT ULevel[MAX_PORTNUM]; // current DS2480B 1-Wire Net level
+extern SMALLINT UBaud[MAX_PORTNUM];  // current DS2480B baud rate
+extern SMALLINT UMode[MAX_PORTNUM];  // current DS2480B command or data mode state
+extern SMALLINT USpeed[MAX_PORTNUM]; // current DS2480B 1-Wire Net communication speed
+extern SMALLINT UVersion[MAX_PORTNUM]; // current DS2480B version
+
+// new global for DS1994/DS2404/DS1427.  If TRUE, puts a delay in owTouchReset to compensate for alarming clocks.
+SMALLINT FAMILY_CODE_04_ALARM_TOUCHRESET_COMPLIANCE = FALSE; // default owTouchReset to quickest response.
+
+// local varable flag, true if program voltage available
+static SMALLINT ProgramAvailable[MAX_PORTNUM];
+
+//--------------------------------------------------------------------------
+// Reset all of the devices on the 1-Wire Net and return the result.
+//
+// 'portnum'    - number 0 to MAX_PORTNUM-1.  This number was provided to
+//                OpenCOM to indicate the port number.
+//
+// Returns: TRUE(1):  presense pulse(s) detected, device(s) reset
+//          FALSE(0): no presense pulses detected
+//
+// WARNING: Without setting the above global (FAMILY_CODE_04_ALARM_TOUCHRESET_COMPLIANCE)
+//          to TRUE, this routine will not function correctly on some
+//          Alarm reset types of the DS1994/DS1427/DS2404 with
+//          Rev 1,2, and 3 of the DS2480/DS2480B.
+//
+//
+SMALLINT owTouchReset(int portnum)
+{
+   uchar readbuffer[10],sendpacket[10];
+   uchar sendlen=0;
+
+   if (dodebug)
+      printf("\nRST ");//??????????????
+
+   // make sure normal level
+   owLevel(portnum,MODE_NORMAL);
+
+   // check if correct mode
+   if (UMode[portnum] != MODSEL_COMMAND)
+   {
+      UMode[portnum] = MODSEL_COMMAND;
+      sendpacket[sendlen++] = MODE_COMMAND;
+   }
+
+   // construct the command
+   sendpacket[sendlen++] = (uchar)(CMD_COMM | FUNCTSEL_RESET | USpeed[portnum]);
+
+   // flush the buffers
+   FlushCOM(portnum);
+
+   // send the packet
+   if (WriteCOM(portnum,sendlen,sendpacket))
+   {
+      // read back the 1 byte response
+      if (ReadCOM(portnum,1,readbuffer) == 1)
+      {
+         // make sure this byte looks like a reset byte
+         if (((readbuffer[0] & RB_RESET_MASK) == RB_PRESENCE) ||
+             ((readbuffer[0] & RB_RESET_MASK) == RB_ALARMPRESENCE))
+         {
+            // check if programming voltage available
+            ProgramAvailable[portnum] = ((readbuffer[0] & 0x20) == 0x20);
+            UVersion[portnum] = (readbuffer[0] & VERSION_MASK);
+
+            // only check for alarm pulse if DS2404 present and not using THE LINK
+            if ((FAMILY_CODE_04_ALARM_TOUCHRESET_COMPLIANCE) &&
+                (UVersion[portnum] != VER_LINK))
+            {
+               msDelay(5); // delay 5 ms to give DS1994 enough time
+               FlushCOM(portnum);
+            }
+            return TRUE;
+         }
+         else
+            OWERROR(OWERROR_RESET_FAILED);
+
+      }
+      else
+         OWERROR(OWERROR_READCOM_FAILED);
+   }
+   else
+      OWERROR(OWERROR_WRITECOM_FAILED);
+
+   // an error occured so re-sync with DS2480
+   DS2480Detect(portnum);
+
+   return FALSE;
+}
+
+//--------------------------------------------------------------------------
+// Send 1 bit of communication to the 1-Wire Net and return the
+// result 1 bit read from the 1-Wire Net.  The parameter 'sendbit'
+// least significant bit is used and the least significant bit
+// of the result is the return bit.
+//
+// 'portnum' - number 0 to MAX_PORTNUM-1.  This number was provided to
+//             OpenCOM to indicate the port number.
+// 'sendbit' - the least significant bit is the bit to send
+//
+// Returns: 0:   0 bit read from sendbit
+//          1:   1 bit read from sendbit
+//
+SMALLINT owTouchBit(int portnum, SMALLINT sendbit)
+{
+   uchar readbuffer[10],sendpacket[10];
+   uchar sendlen=0;
+
+   // make sure normal level
+   owLevel(portnum,MODE_NORMAL);
+
+   // check if correct mode
+   if (UMode[portnum] != MODSEL_COMMAND)
+   {
+      UMode[portnum] = MODSEL_COMMAND;
+      sendpacket[sendlen++] = MODE_COMMAND;
+   }
+
+   // construct the command
+   sendpacket[sendlen] = (sendbit != 0) ? BITPOL_ONE : BITPOL_ZERO;
+   sendpacket[sendlen++] |= CMD_COMM | FUNCTSEL_BIT | USpeed[portnum];
+
+   // flush the buffers
+   FlushCOM(portnum);
+
+   // send the packet
+   if (WriteCOM(portnum,sendlen,sendpacket))
+   {
+      // read back the response
+      if (ReadCOM(portnum,1,readbuffer) == 1)
+      {
+         // interpret the response
+         if (((readbuffer[0] & 0xE0) == 0x80) &&
+             ((readbuffer[0] & RB_BIT_MASK) == RB_BIT_ONE))
+            return 1;
+         else
+            return 0;
+      }
+      else
+         OWERROR(OWERROR_READCOM_FAILED);
+   }
+   else
+      OWERROR(OWERROR_WRITECOM_FAILED);
+
+   // an error occured so re-sync with DS2480
+   DS2480Detect(portnum);
+
+   return 0;
+}
+
+//--------------------------------------------------------------------------
+// Send 8 bits of communication to the 1-Wire Net and verify that the
+// 8 bits read from the 1-Wire Net is the same (write operation).
+// The parameter 'sendbyte' least significant 8 bits are used.
+//
+// 'portnum'  - number 0 to MAX_PORTNUM-1.  This number was provided to
+//              OpenCOM to indicate the port number.
+// 'sendbyte' - 8 bits to send (least significant byte)
+//
+// Returns:  TRUE: bytes written and echo was the same
+//           FALSE: echo was not the same
+//
+SMALLINT owWriteByte(int portnum, SMALLINT sendbyte)
+{
+   return (owTouchByte(portnum,sendbyte) == (0xff & sendbyte)) ? TRUE : FALSE;
+}
+
+
+//--------------------------------------------------------------------------
+// Send 8 bits of read communication to the 1-Wire Net and and return the
+// result 8 bits read from the 1-Wire Net.
+//
+// 'portnum'  - number 0 to MAX_PORTNUM-1.  This number was provided to
+//              OpenCOM to indicate the port number.
+//
+// Returns:  8 bits read from 1-Wire Net
+//
+SMALLINT owReadByte(int portnum)
+{
+   return owTouchByte(portnum,(SMALLINT)0xFF);
+}
+
+//--------------------------------------------------------------------------
+// Send 8 bits of communication to the 1-Wire Net and return the
+// result 8 bits read from the 1-Wire Net.  The parameter 'sendbyte'
+// least significant 8 bits are used and the least significant 8 bits
+// of the result is the return byte.
+//
+// 'portnum'  - number 0 to MAX_PORTNUM-1.  This number was provided to
+//              OpenCOM to indicate the port number.
+// 'sendbyte' - 8 bits to send (least significant byte)
+//
+// Returns:  8 bits read from sendbyte
+//
+SMALLINT owTouchByte(int portnum, SMALLINT sendbyte)
+{
+   uchar readbuffer[10],sendpacket[10];
+   uchar sendlen=0;
+
+   // make sure normal level
+   owLevel(portnum,MODE_NORMAL);
+
+   // check if correct mode
+   if (UMode[portnum] != MODSEL_DATA)
+   {
+      UMode[portnum] = MODSEL_DATA;
+      sendpacket[sendlen++] = MODE_DATA;
+   }
+
+   // add the byte to send
+   sendpacket[sendlen++] = (uchar)sendbyte;
+
+   // check for duplication of data that looks like COMMAND mode
+   if (sendbyte ==(SMALLINT)MODE_COMMAND)
+      sendpacket[sendlen++] = (uchar)sendbyte;
+
+   // flush the buffers
+   FlushCOM(portnum);
+
+   // send the packet
+   if (WriteCOM(portnum,sendlen,sendpacket))
+   {
+      // read back the 1 byte response
+      if (ReadCOM(portnum,1,readbuffer) == 1)
+      {
+         if (dodebug)
+            printf("%02X ",readbuffer[0]);//??????????????
+
+          // return the response
+          return (int)readbuffer[0];
+      }
+      else
+         OWERROR(OWERROR_READCOM_FAILED);
+   }
+   else
+      OWERROR(OWERROR_WRITECOM_FAILED);
+
+   // an error occured so re-sync with DS2480
+   DS2480Detect(portnum);
+
+   return 0;
+}
+
+//--------------------------------------------------------------------------
+// Set the 1-Wire Net communucation speed.
+//
+// 'portnum'   - number 0 to MAX_PORTNUM-1.  This number was provided to
+//               OpenCOM to indicate the port number.
+// 'new_speed' - new speed defined as
+//                MODE_NORMAL     0x00
+//                MODE_OVERDRIVE  0x01
+//
+// Returns:  current 1-Wire Net speed
+//
+SMALLINT owSpeed(int portnum, SMALLINT new_speed)
+{
+   uchar sendpacket[5];
+   uchar sendlen=0;
+   uchar rt = FALSE;
+
+   // check if change from current mode
+   if (((new_speed == MODE_OVERDRIVE) &&
+        (USpeed[portnum] != SPEEDSEL_OD)) ||
+       ((new_speed == MODE_NORMAL) &&
+        (USpeed[portnum] != SPEEDSEL_FLEX)))
+   {
+      if (new_speed == MODE_OVERDRIVE)
+      {
+         // check for unsupported mode in THE LINK
+         if (UVersion[portnum] == VER_LINK)
+            OWERROR(OWERROR_FUNC_NOT_SUP);
+         // if overdrive then switch to higher baud
+         else if (DS2480ChangeBaud(portnum,MAX_BAUD) == MAX_BAUD)
+         {
+            USpeed[portnum] = SPEEDSEL_OD;
+            rt = TRUE;
+         }
+      }
+      else if (new_speed == MODE_NORMAL)
+      {
+         // else normal so set to 9600 baud
+         if (DS2480ChangeBaud(portnum,PARMSET_9600) == PARMSET_9600)
+         {
+            USpeed[portnum] = SPEEDSEL_FLEX;
+            rt = TRUE;
+         }
+
+      }
+
+      // if baud rate is set correctly then change DS2480 speed
+      if (rt)
+      {
+         // check if correct mode
+         if (UMode[portnum] != MODSEL_COMMAND)
+         {
+            UMode[portnum] = MODSEL_COMMAND;
+            sendpacket[sendlen++] = MODE_COMMAND;
+         }
+
+         // proceed to set the DS2480 communication speed
+         sendpacket[sendlen++] = CMD_COMM | FUNCTSEL_SEARCHOFF | USpeed[portnum];
+
+         // send the packet
+         if (!WriteCOM(portnum,sendlen,sendpacket))
+         {
+            OWERROR(OWERROR_WRITECOM_FAILED);
+            rt = FALSE;
+            // lost communication with DS2480 then reset
+            DS2480Detect(portnum);
+         }
+      }
+   }
+
+   // return the current speed
+   return (USpeed[portnum] == SPEEDSEL_OD) ? MODE_OVERDRIVE : MODE_NORMAL;
+}
+
+//--------------------------------------------------------------------------
+// Set the 1-Wire Net line level.  The values for new_level are
+// as follows:
+//
+// 'portnum'   - number 0 to MAX_PORTNUM-1.  This number was provided to
+//               OpenCOM to indicate the port number.
+// 'new_level' - new level defined as
+//                MODE_NORMAL     0x00
+//                MODE_STRONG5    0x02
+//                MODE_PROGRAM    0x04
+//                MODE_BREAK      0x08 (not supported)
+//
+// Returns:  current 1-Wire Net level
+//
+SMALLINT owLevel(int portnum, SMALLINT new_level)
+{
+   uchar sendpacket[10],readbuffer[10];
+   uchar sendlen=0;
+   uchar rt=FALSE;
+
+   // check if need to change level
+   if (new_level != ULevel[portnum])
+   {
+      // check if correct mode
+      if (UMode[portnum] != MODSEL_COMMAND)
+      {
+         UMode[portnum] = MODSEL_COMMAND;
+         sendpacket[sendlen++] = MODE_COMMAND;
+      }
+
+      // check if just putting back to normal
+      if (new_level == MODE_NORMAL)
+      {
+         // stop pulse command
+         sendpacket[sendlen++] = MODE_STOP_PULSE;
+
+         // add the command to begin the pulse WITHOUT prime
+         sendpacket[sendlen++] = CMD_COMM | FUNCTSEL_CHMOD | SPEEDSEL_PULSE | BITPOL_5V | PRIME5V_FALSE;
+
+         // stop pulse command
+         sendpacket[sendlen++] = MODE_STOP_PULSE;
+
+         // flush the buffers
+         FlushCOM(portnum);
+
+         // send the packet
+         if (WriteCOM(portnum,sendlen,sendpacket))
+         {
+            // read back the 2 byte response
+            if (ReadCOM(portnum,2,readbuffer) == 2)
+            {
+               // check response byte
+               if (((readbuffer[0] & 0xE0) == 0xE0) &&
+                   ((readbuffer[1] & 0xE0) == 0xE0))
+               {
+                  rt = TRUE;
+                  ULevel[portnum] = MODE_NORMAL;
+               }
+            }
+            else
+               OWERROR(OWERROR_READCOM_FAILED);
+         }
+         else
+            OWERROR(OWERROR_WRITECOM_FAILED);
+      }
+      // set new level
+      else
+      {
+         // strong 5 volts
+         if (new_level == MODE_STRONG5)
+         {
+            // set the SPUD time value
+            sendpacket[sendlen++] = CMD_CONFIG | PARMSEL_5VPULSE | PARMSET_infinite;
+            // add the command to begin the pulse
+            sendpacket[sendlen++] = CMD_COMM | FUNCTSEL_CHMOD | SPEEDSEL_PULSE | BITPOL_5V;
+         }
+         // 12 volts
+         else if (new_level == MODE_PROGRAM)
+         {
+            // check if programming voltage available
+            if (!ProgramAvailable[portnum])
+               return MODE_NORMAL;
+
+            // set the PPD time value
+            sendpacket[sendlen++] = CMD_CONFIG | PARMSEL_12VPULSE | PARMSET_infinite;
+            // add the command to begin the pulse
+            sendpacket[sendlen++] = CMD_COMM | FUNCTSEL_CHMOD | SPEEDSEL_PULSE | BITPOL_12V;
+         }
+
+         // flush the buffers
+         FlushCOM(portnum);
+
+         // send the packet
+         if (WriteCOM(portnum,sendlen,sendpacket))
+         {
+            // read back the 1 byte response from setting time limit
+            if (ReadCOM(portnum,1,readbuffer) == 1)
+            {
+               // check response byte
+               if ((readbuffer[0] & 0x81) == 0)
+               {
+                  ULevel[portnum] = new_level;
+                  rt = TRUE;
+               }
+            }
+            else
+               OWERROR(OWERROR_READCOM_FAILED);
+         }
+         else
+            OWERROR(OWERROR_WRITECOM_FAILED);
+      }
+
+      // if lost communication with DS2480 then reset
+      if (rt != TRUE)
+         DS2480Detect(portnum);
+   }
+
+   // return the current level
+   return ULevel[portnum];
+}
+
+//--------------------------------------------------------------------------
+// This procedure creates a fixed 480 microseconds 12 volt pulse
+// on the 1-Wire Net for programming EPROM iButtons.
+//
+// 'portnum'  - number 0 to MAX_PORTNUM-1.  This number was provided to
+//              OpenCOM to indicate the port number.
+//
+// Returns:  TRUE  successful
+//           FALSE program voltage not available
+//
+SMALLINT owProgramPulse(int portnum)
+{
+   uchar sendpacket[10],readbuffer[10];
+   uchar sendlen=0;
+
+   // check if programming voltage available
+   if (!ProgramAvailable[portnum])
+      return FALSE;
+
+   // make sure normal level
+   owLevel(portnum,MODE_NORMAL);
+
+   // check if correct mode
+   if (UMode[portnum] != MODSEL_COMMAND)
+   {
+      UMode[portnum] = MODSEL_COMMAND;
+      sendpacket[sendlen++] = MODE_COMMAND;
+   }
+
+   // set the SPUD time value
+   sendpacket[sendlen++] = CMD_CONFIG | PARMSEL_12VPULSE | PARMSET_512us;
+
+   // pulse command
+   sendpacket[sendlen++] = CMD_COMM | FUNCTSEL_CHMOD | BITPOL_12V | SPEEDSEL_PULSE;
+
+   // flush the buffers
+   FlushCOM(portnum);
+
+   // send the packet
+   if (WriteCOM(portnum,sendlen,sendpacket))
+   {
+      // read back the 2 byte response
+      if (ReadCOM(portnum,2,readbuffer) == 2)
+      {
+         // check response byte
+         if (((readbuffer[0] | CMD_CONFIG) ==
+                (CMD_CONFIG | PARMSEL_12VPULSE | PARMSET_512us)) &&
+             ((readbuffer[1] & 0xFC) ==
+                (0xFC & (CMD_COMM | FUNCTSEL_CHMOD | BITPOL_12V | SPEEDSEL_PULSE))))
+            return TRUE;
+      }
+      else
+         OWERROR(OWERROR_READCOM_FAILED);
+   }
+   else
+      OWERROR(OWERROR_WRITECOM_FAILED);
+
+   // an error occured so re-sync with DS2480
+   DS2480Detect(portnum);
+
+   return FALSE;
+}
+
+//--------------------------------------------------------------------------
+// Send 8 bits of communication to the 1-Wire Net and verify that the
+// 8 bits read from the 1-Wire Net is the same (write operation).
+// The parameter 'sendbyte' least significant 8 bits are used.  After the
+// 8 bits are sent change the level of the 1-Wire net.
+//
+// 'portnum'  - number 0 to MAX_PORTNUM-1.  This number was provided to
+//              OpenCOM to indicate the port number.
+// 'sendbyte' - 8 bits to send (least significant bit)
+//
+// Returns:  TRUE: bytes written and echo was the same, strong pullup now on
+//           FALSE: echo was not the same
+//
+SMALLINT owWriteBytePower(int portnum, SMALLINT sendbyte)
+{
+   uchar sendpacket[10],readbuffer[10];
+   uchar sendlen=0;
+   uchar rt=FALSE;
+   uchar i, temp_byte;
+
+   if (dodebug)
+      printf("P%02X ",sendbyte);//??????????????
+
+   // check if correct mode
+   if (UMode[portnum] != MODSEL_COMMAND)
+   {
+      UMode[portnum] = MODSEL_COMMAND;
+      sendpacket[sendlen++] = MODE_COMMAND;
+   }
+
+   // set the SPUD time value
+   sendpacket[sendlen++] = CMD_CONFIG | PARMSEL_5VPULSE | PARMSET_infinite;
+
+   // construct the stream to include 8 bit commands with the last one
+   // enabling the strong-pullup
+   temp_byte = sendbyte;
+   for (i = 0; i < 8; i++)
+   {
+      sendpacket[sendlen++] = ((temp_byte & 0x01) ? BITPOL_ONE : BITPOL_ZERO)
+                              | CMD_COMM | FUNCTSEL_BIT | USpeed[portnum] |
+                              ((i == 7) ? PRIME5V_TRUE : PRIME5V_FALSE);
+      temp_byte >>= 1;
+   }
+
+   // flush the buffers
+   FlushCOM(portnum);
+
+   // send the packet
+   if (WriteCOM(portnum,sendlen,sendpacket))
+   {
+      // read back the 9 byte response from setting time limit
+      if (ReadCOM(portnum,9,readbuffer) == 9)
+      {
+         // check response
+         if ((readbuffer[0] & 0x81) == 0)
+         {
+            // indicate the port is now at power delivery
+            ULevel[portnum] = MODE_STRONG5;
+
+            // reconstruct the echo byte
+            temp_byte = 0;
+            for (i = 0; i < 8; i++)
+            {
+               temp_byte >>= 1;
+               temp_byte |= (readbuffer[i + 1] & 0x01) ? 0x80 : 0;
+            }
+
+            if (temp_byte == sendbyte)
+               rt = TRUE;
+         }
+      }
+      else
+         OWERROR(OWERROR_READCOM_FAILED);
+   }
+   else
+      OWERROR(OWERROR_WRITECOM_FAILED);
+
+   // if lost communication with DS2480 then reset
+   if (rt != TRUE)
+      DS2480Detect(portnum);
+
+   return rt;
+}
+
+//--------------------------------------------------------------------------
+// Send 8 bits of communication to the 1-Wire Net and verify that the
+// 8 bits read from the 1-Wire Net is the same (write operation).
+// The parameter 'sendbyte' least significant 8 bits are used.  After the
+// 8 bits are sent change the level of the 1-Wire net.
+//
+// 'portnum'  - number 0 to MAX_PORTNUM-1.  This number was provided to
+//              OpenCOM to indicate the port number.
+// 'sendbyte' - 8 bits to send (least significant bit)
+//
+// Returns:  TRUE: bytes written and echo was the same, strong pullup now on
+//           FALSE: echo was not the same
+//
+SMALLINT owReadBytePower(int portnum)
+{
+   uchar sendpacket[10],readbuffer[10];
+   uchar sendlen=0;
+   uchar rt=FALSE;
+   uchar i, temp_byte;
+
+   // check if correct mode
+   if (UMode[portnum] != MODSEL_COMMAND)
+   {
+      UMode[portnum] = MODSEL_COMMAND;
+      sendpacket[sendlen++] = MODE_COMMAND;
+   }
+
+   // set the SPUD time value
+   sendpacket[sendlen++] = CMD_CONFIG | PARMSEL_5VPULSE | PARMSET_infinite;
+
+   // construct the stream to include 8 bit commands with the last one
+   // enabling the strong-pullup
+   temp_byte = 0xFF;
+   for (i = 0; i < 8; i++)
+   {
+      sendpacket[sendlen++] = ((temp_byte & 0x01) ? BITPOL_ONE : BITPOL_ZERO)
+                              | CMD_COMM | FUNCTSEL_BIT | USpeed[portnum] |
+                              ((i == 7) ? PRIME5V_TRUE : PRIME5V_FALSE);
+      temp_byte >>= 1;
+   }
+
+   // flush the buffers
+   FlushCOM(portnum);
+
+   // send the packet
+   if (WriteCOM(portnum,sendlen,sendpacket))
+   {
+      // read back the 9 byte response from setting time limit
+      if (ReadCOM(portnum,9,readbuffer) == 9)
+      {
+         // check response
+         if ((readbuffer[0] & 0x81) == 0)
+         {
+            // indicate the port is now at power delivery
+            ULevel[portnum] = MODE_STRONG5;
+
+            // reconstruct the return byte
+            temp_byte = 0;
+            for (i = 0; i < 8; i++)
+            {
+               temp_byte >>= 1;
+               temp_byte |= (readbuffer[i + 1] & 0x01) ? 0x80 : 0;
+            }
+
+            rt = TRUE;
+         }
+      }
+      else
+         OWERROR(OWERROR_READCOM_FAILED);
+   }
+   else
+      OWERROR(OWERROR_WRITECOM_FAILED);
+
+   // if lost communication with DS2480 then reset
+   if (rt != TRUE)
+      DS2480Detect(portnum);
+
+   if (dodebug)
+      printf("PFF%02X ",temp_byte);//??????????????
+
+   return temp_byte;
+}
+
+
+//--------------------------------------------------------------------------
+// Send 1 bit of communication to the 1-Wire Net and verify that the
+// response matches the 'applyPowerResponse' bit and apply power delivery
+// to the 1-Wire net.  Note that some implementations may apply the power
+// first and then turn it off if the response is incorrect.
+//
+// 'portnum'  - number 0 to MAX_PORTNUM-1.  This number was provided to
+//              OpenCOM to indicate the port number.
+// 'applyPowerResponse' - 1 bit response to check, if correct then start
+//                        power delivery
+//
+// Returns:  TRUE: bit written and response correct, strong pullup now on
+//           FALSE: response incorrect
+//
+SMALLINT owReadBitPower(int portnum, SMALLINT applyPowerResponse)
+{
+   uchar sendpacket[3],readbuffer[3];
+   uchar sendlen=0;
+   uchar rt=FALSE;
+
+   // check if correct mode
+   if (UMode[portnum] != MODSEL_COMMAND)
+   {
+      UMode[portnum] = MODSEL_COMMAND;
+      sendpacket[sendlen++] = MODE_COMMAND;
+   }
+
+   // set the SPUD time value
+   sendpacket[sendlen++] = CMD_CONFIG | PARMSEL_5VPULSE | PARMSET_infinite;
+
+   // enabling the strong-pullup after bit
+   sendpacket[sendlen++] = BITPOL_ONE
+                           | CMD_COMM | FUNCTSEL_BIT | USpeed[portnum] |
+                           PRIME5V_TRUE;
+   // flush the buffers
+   FlushCOM(portnum);
+
+   // send the packet
+   if (WriteCOM(portnum,sendlen,sendpacket))
+   {
+      // read back the 2 byte response from setting time limit
+      if (ReadCOM(portnum,2,readbuffer) == 2)
+      {
+         // check response to duration set
+         if ((readbuffer[0] & 0x81) == 0)
+         {
+            // indicate the port is now at power delivery
+            ULevel[portnum] = MODE_STRONG5;
+
+            // check the response bit
+            if ((readbuffer[1] & 0x01) == applyPowerResponse)
+               rt = TRUE;
+            else
+               owLevel(portnum,MODE_NORMAL);
+
+            return rt;
+         }
+      }
+      else
+         OWERROR(OWERROR_READCOM_FAILED);
+   }
+   else
+      OWERROR(OWERROR_WRITECOM_FAILED);
+
+   // if lost communication with DS2480 then reset
+   if (rt != TRUE)
+      DS2480Detect(portnum);
+
+   return rt;
+}
+
+//--------------------------------------------------------------------------
+// This procedure indicates whether the adapter can deliver power.
+//
+// 'portnum'  - number 0 to MAX_PORTNUM-1.  This number was provided to
+//              OpenCOM to indicate the port number.
+//
+// Returns:  TRUE  because all userial adapters have over drive.
+//
+SMALLINT owHasPowerDelivery(int portnum)
+{
+   return TRUE;
+}
+
+//--------------------------------------------------------------------------
+// This procedure indicates wether the adapter can deliver power.
+//
+// 'portnum'  - number 0 to MAX_PORTNUM-1.  This number was provided to
+//              OpenCOM to indicate the port number.
+//
+// Returns:  TRUE  because all userial adapters have over drive.
+//
+SMALLINT owHasOverDrive(int portnum)
+{
+   return TRUE;
+}
+//--------------------------------------------------------------------------
+// This procedure creates a fixed 480 microseconds 12 volt pulse
+// on the 1-Wire Net for programming EPROM iButtons.
+//
+// 'portnum'  - number 0 to MAX_PORTNUM-1.  This number was provided to
+//              OpenCOM to indicate the port number.
+//
+// Returns:  TRUE  program volatage available
+//           FALSE program voltage not available
+SMALLINT owHasProgramPulse(int portnum)
+{
+   return ProgramAvailable[portnum];
+}

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ibutton/ownet.h
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ibutton/ownet.h
@@ -1,0 +1,440 @@
+/*---------------------------------------------------------------------------
+ * Copyright (C) 2000 Dallas Semiconductor Corporation, All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY,  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL DALLAS SEMICONDUCTOR BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Except as contained in this notice, the name of Dallas Semiconductor
+ * shall not be used except as stated in the Dallas Semiconductor
+ * Branding Policy.
+ *---------------------------------------------------------------------------
+ *
+ * ownet.h - Include file for 1-Wire Net library
+ *
+ * Version: 2.10
+ *
+ * History: 1.02 -> 1.03 Make sure uchar is not defined twice.
+ *          1.03 -> 2.00 Changed 'MLan' to 'ow'.
+ *          2.00 -> 2.01 Added error handling. Added circular-include check.
+ *          2.01 -> 2.10 Added raw memory error handling and SMALLINT
+ *          2.10 -> 3.00 Added memory bank functionality
+ *                       Added file I/O operations
+ */
+
+#ifndef OWNET_H
+#define OWNET_H
+
+/* Vyhd note: if I'm ever adventurous enough, I'll fix this up and manually
+ * get rid of the warnings. Until then, there's #pragma warning. */
+
+#ifdef _MSC_VER
+#pragma warning (disable : 4100) /* unreferenced formal parameter */
+#pragma warning (disable : 4244) /* conversion from blah to blah, possible loss of data */
+#pragma warning (disable : 4701) /* local variable may be used without having been initialized */
+#endif
+
+/*-------------------------------------------------------------*
+ * Common Includes to ownet applications                       *
+ *-------------------------------------------------------------*/
+#include <stdlib.h>
+
+/* Workaround for Windows compilation.
+ * The below doesn't actually work. :/
+ */
+typedef unsigned short ushort;
+typedef unsigned long ulong;
+
+/*-------------------------------------------------------------*
+ * Target Specific Information                                 *
+ *-------------------------------------------------------------*/
+
+/*-------------------------------------------------------------*
+ * Handhelds (PalmOS, WinCE)                                   *
+ *-------------------------------------------------------------*/
+#ifdef __MC68K__
+   /* MC68K is the type of processor in the PILOT
+    * Metrowerk's CodeWarrior defines this symbol
+    */
+   #include <string.h>
+   #ifndef strcmp
+      #include <StringMgr.h>
+      #define strcmp StrCompare
+   #endif
+   #include <file_struc.h>
+#endif
+
+#ifdef _WIN32_WCE
+   /* All of our projects had this flag defined by default (_WIN32_WCE),
+    * but I'm not 100% positive that this is _the_ definitive
+    * flag to use to identify a WinCE system.
+    */
+   #include "WinCElnk.h"
+   #ifndef FILE
+      #define FILE int
+      extern int sprintf(char *buffer, char *format,...);
+      extern void fprintf(FILE *fp, char *format,...);
+      extern void printf(char *format,...);
+   #endif
+#endif
+
+#if !defined(_WIN32_WCE) && !defined(__MC68K__)
+   #include <stdio.h>
+#endif
+
+#ifdef __C51__
+   #define FILE int
+   #define exit(c) return
+   typedef unsigned int ushort;
+   typedef unsigned long ulong;
+   #define SMALLINT uchar
+#endif
+
+#ifdef __ICCMAXQ__
+   #define FILE int
+   #define stdout 0
+   #define stdin  1
+   #define stderr 2
+   typedef unsigned int ushort;
+   typedef unsigned long ulong;
+   #define SMALLINT short
+   #define main micro_main
+   #define real_main main
+   #define SMALL_MEMORY_TARGET
+#endif
+
+
+/*--------------------------------------------------------------*
+ * Typedefs                                                     *
+ *--------------------------------------------------------------*/
+#ifndef SMALLINT
+   /* purpose of smallint is for compile-time changing of formal
+    * parameters and return values of functions.  For each target
+    * machine, an integer is alleged to represent the most "simple"
+    * number representable by that architecture.  This should, in
+    * most cases, produce optimal code for that particular arch.
+    * BUT...  The majority of compilers designed for embedded
+    * processors actually keep an int at 16 bits, although the
+    * architecture might only be comfortable with 8 bits.
+    * The default size of smallint will be the same as that of
+    * an integer, but this allows for easy overriding of that size.
+    *
+    * NOTE:
+    * In all cases where a smallint is used, it is assumed that
+    * decreasing the size of this integer to something as low as
+    * a single byte _will_not_ change the functionality of the
+    * application.  e.g. a loop counter that will iterate through
+    * several kilobytes of data should not be SMALLINT.  The most
+    * common place you'll see smallint is for boolean return types.
+    */
+   #define SMALLINT int
+#endif
+
+/* setting max baud */
+#ifdef _WINDOWS
+   /* 0x02 = PARAMSET_19200 */
+#define MAX_BAUD 0x02
+#else
+   /* 0x06 = PARMSET_115200 */
+#define MAX_BAUD 0x06
+#endif
+
+#ifndef OW_UCHAR
+   #define OW_UCHAR
+   typedef unsigned char uchar;
+   #if !defined(__MINGW32__) && (defined(__CYGWIN__) || defined(__GNUC__))
+      typedef unsigned long ulong;
+      /* ushort already defined in sys/types.h */
+      #include <sys/types.h>
+   #else
+      #if defined(_WIN32) || defined(WIN32) || defined(__MC68K__) || defined(_WIN32_WCE) || defined(_DOS)  || defined(_WINDOWS) || defined(__MINGW32__)
+         typedef unsigned short ushort;
+         typedef unsigned long ulong;
+      #endif
+   #endif
+   #ifdef __sun__
+      #include <sys/types.h>
+   #endif
+   #ifdef SDCC
+      /* intent of ushort is 2 bytes unsigned.
+       * for ds390 in sdcc, an int, not a short,
+       * is 2 bytes.
+       */
+      typedef unsigned int ushort;
+   #endif
+#endif
+
+/* general defines */
+#define WRITE_FUNCTION 1
+#define READ_FUNCTION  0
+
+/* error codes
+ * todo: investigate these and replace with new Error Handling library
+ */
+#define READ_ERROR    -1
+#define INVALID_DIR   -2
+#define NO_FILE       -3
+#define WRITE_ERROR   -4
+#define WRONG_TYPE    -5
+#define FILE_TOO_BIG  -6
+
+/* Misc */
+#define FALSE          0
+#define TRUE           1
+
+#ifndef MAX_PORTNUM
+   #define MAX_PORTNUM    16
+#endif
+
+/* mode bit flags */
+#define MODE_NORMAL                    0x00
+#define MODE_OVERDRIVE                 0x01
+#define MODE_STRONG5                   0x02
+#define MODE_PROGRAM                   0x04
+#define MODE_BREAK                     0x08
+
+/* Output flags */
+#define LV_ALWAYS          2
+#define LV_OPTIONAL        1
+#define LV_VERBOSE         0
+
+/*--------------------------------------------------------------*
+ * Error handling                                               *
+ *--------------------------------------------------------------*/
+extern int owGetErrorNum(void);
+extern int owHasErrors(void);
+
+/* Clears the stack. */
+#define OWERROR_CLEAR() while(owHasErrors()) owGetErrorNum();
+
+#ifdef DEBUG
+   /* Raises an exception with extra debug info */
+   #define OWERROR(err) owRaiseError(err,__LINE__,__FILE__)
+   extern void owRaiseError(int,int,char*);
+   #define OWASSERT(s,err,ret) if(!(s)){owRaiseError((err),__LINE__,__FILE__);return (ret);}
+#else
+   /* Raises an exception with just the error code */
+   #define OWERROR(err) owRaiseError(err)
+   extern void owRaiseError(int);
+   #define OWASSERT(s,err,ret) if(!(s)){owRaiseError((err));return (ret);}
+#endif
+
+#ifdef SMALL_MEMORY_TARGET
+   #define OWERROR_DUMP(fileno) /*no-op*/;
+#else
+   /* Prints the stack out to the given file. */
+   #define OWERROR_DUMP(fileno) while(owHasErrors()) owPrintErrorMsg(fileno);
+   extern void owPrintErrorMsg(FILE *);
+   extern void owPrintErrorMsgStd();
+   extern char *owGetErrorMsg(int);
+#endif
+
+#define OWERROR_NO_ERROR_SET                    0
+#define OWERROR_NO_DEVICES_ON_NET               1
+#define OWERROR_RESET_FAILED                    2
+#define OWERROR_SEARCH_ERROR                    3
+#define OWERROR_ACCESS_FAILED                   4
+#define OWERROR_DS2480_NOT_DETECTED             5
+#define OWERROR_DS2480_WRONG_BAUD               6
+#define OWERROR_DS2480_BAD_RESPONSE             7
+#define OWERROR_OPENCOM_FAILED                  8
+#define OWERROR_WRITECOM_FAILED                 9
+#define OWERROR_READCOM_FAILED                  10
+#define OWERROR_BLOCK_TOO_BIG                   11
+#define OWERROR_BLOCK_FAILED                    12
+#define OWERROR_PROGRAM_PULSE_FAILED            13
+#define OWERROR_PROGRAM_BYTE_FAILED             14
+#define OWERROR_WRITE_BYTE_FAILED               15
+#define OWERROR_READ_BYTE_FAILED                16
+#define OWERROR_WRITE_VERIFY_FAILED             17
+#define OWERROR_READ_VERIFY_FAILED              18
+#define OWERROR_WRITE_SCRATCHPAD_FAILED         19
+#define OWERROR_COPY_SCRATCHPAD_FAILED          20
+#define OWERROR_INCORRECT_CRC_LENGTH            21
+#define OWERROR_CRC_FAILED                      22
+#define OWERROR_GET_SYSTEM_RESOURCE_FAILED      23
+#define OWERROR_SYSTEM_RESOURCE_INIT_FAILED     24
+#define OWERROR_DATA_TOO_LONG                   25
+#define OWERROR_READ_OUT_OF_RANGE               26
+#define OWERROR_WRITE_OUT_OF_RANGE              27
+#define OWERROR_DEVICE_SELECT_FAIL              28
+#define OWERROR_READ_SCRATCHPAD_VERIFY          29
+#define OWERROR_COPY_SCRATCHPAD_NOT_FOUND       30
+#define OWERROR_ERASE_SCRATCHPAD_NOT_FOUND      31
+#define OWERROR_ADDRESS_READ_BACK_FAILED        32
+#define OWERROR_EXTRA_INFO_NOT_SUPPORTED        33
+#define OWERROR_PG_PACKET_WITHOUT_EXTRA         34
+#define OWERROR_PACKET_LENGTH_EXCEEDS_PAGE      35
+#define OWERROR_INVALID_PACKET_LENGTH           36
+#define OWERROR_NO_PROGRAM_PULSE                37
+#define OWERROR_READ_ONLY                       38
+#define OWERROR_NOT_GENERAL_PURPOSE             39
+#define OWERROR_READ_BACK_INCORRECT             40
+#define OWERROR_INVALID_PAGE_NUMBER             41
+#define OWERROR_CRC_NOT_SUPPORTED               42
+#define OWERROR_CRC_EXTRA_INFO_NOT_SUPPORTED    43
+#define OWERROR_READ_BACK_NOT_VALID             44
+#define OWERROR_COULD_NOT_LOCK_REDIRECT         45
+#define OWERROR_READ_STATUS_NOT_COMPLETE        46
+#define OWERROR_PAGE_REDIRECTION_NOT_SUPPORTED  47
+#define OWERROR_LOCK_REDIRECTION_NOT_SUPPORTED  48
+#define OWERROR_READBACK_EPROM_FAILED           49
+#define OWERROR_PAGE_LOCKED                     50
+#define OWERROR_LOCKING_REDIRECTED_PAGE_AGAIN   51
+#define OWERROR_REDIRECTED_PAGE                 52
+#define OWERROR_PAGE_ALREADY_LOCKED             53
+#define OWERROR_WRITE_PROTECTED                 54
+#define OWERROR_NONMATCHING_MAC                 55
+#define OWERROR_WRITE_PROTECT                   56
+#define OWERROR_WRITE_PROTECT_SECRET            57
+#define OWERROR_COMPUTE_NEXT_SECRET             58
+#define OWERROR_LOAD_FIRST_SECRET               59
+#define OWERROR_POWER_NOT_AVAILABLE             60
+#define OWERROR_XBAD_FILENAME                   61
+#define OWERROR_XUNABLE_TO_CREATE_DIR           62
+#define OWERROR_REPEAT_FILE                     63
+#define OWERROR_DIRECTORY_NOT_EMPTY             64
+#define OWERROR_WRONG_TYPE                      65
+#define OWERROR_BUFFER_TOO_SMALL                66
+#define OWERROR_NOT_WRITE_ONCE                  67
+#define OWERROR_FILE_NOT_FOUND                  68
+#define OWERROR_OUT_OF_SPACE                    69
+#define OWERROR_TOO_LARGE_BITNUM                70
+#define OWERROR_NO_PROGRAM_JOB                  71
+#define OWERROR_FUNC_NOT_SUP                    72
+#define OWERROR_HANDLE_NOT_USED                 73
+#define OWERROR_FILE_WRITE_ONLY                 74
+#define OWERROR_HANDLE_NOT_AVAIL                75
+#define OWERROR_INVALID_DIRECTORY               76
+#define OWERROR_HANDLE_NOT_EXIST                77
+#define OWERROR_NONMATCHING_SNUM                78
+#define OWERROR_NON_PROGRAM_PARTS               79
+#define OWERROR_PROGRAM_WRITE_PROTECT           80
+#define OWERROR_FILE_READ_ERR                   81
+#define OWERROR_ADDFILE_TERMINATED              82
+#define OWERROR_READ_MEMORY_PAGE_FAILED         83
+#define OWERROR_MATCH_SCRATCHPAD_FAILED         84
+#define OWERROR_ERASE_SCRATCHPAD_FAILED         85
+#define OWERROR_READ_SCRATCHPAD_FAILED          86
+#define OWERROR_SHA_FUNCTION_FAILED             87
+#define OWERROR_NO_COMPLETION_BYTE              88
+#define OWERROR_WRITE_DATA_PAGE_FAILED          89
+#define OWERROR_COPY_SECRET_FAILED              90
+#define OWERROR_BIND_SECRET_FAILED              91
+#define OWERROR_INSTALL_SECRET_FAILED           92
+#define OWERROR_VERIFY_SIG_FAILED               93
+#define OWERROR_SIGN_SERVICE_DATA_FAILED        94
+#define OWERROR_VERIFY_AUTH_RESPONSE_FAILED     95
+#define OWERROR_ANSWER_CHALLENGE_FAILED         96
+#define OWERROR_CREATE_CHALLENGE_FAILED         97
+#define OWERROR_BAD_SERVICE_DATA                98
+#define OWERROR_SERVICE_DATA_NOT_UPDATED        99
+#define OWERROR_CATASTROPHIC_SERVICE_FAILURE    100
+#define OWERROR_LOAD_FIRST_SECRET_FAILED        101
+#define OWERROR_MATCH_SERVICE_SIGNATURE_FAILED  102
+#define OWERROR_KEY_OUT_OF_RANGE                103
+#define OWERROR_BLOCK_ID_OUT_OF_RANGE           104
+#define OWERROR_PASSWORDS_ENABLED               105
+#define OWERROR_PASSWORD_INVALID                106
+#define OWERROR_NO_READ_ONLY_PASSWORD           107
+#define OWERROR_NO_READ_WRITE_PASSWORD          108
+#define OWERROR_OW_SHORTED                      109
+#define OWERROR_ADAPTER_ERROR                   110
+#define OWERROR_EOP_COPY_SCRATCHPAD_FAILED      111
+#define OWERROR_EOP_WRITE_SCRATCHPAD_FAILED     112
+#define OWERROR_HYGRO_STOP_MISSION_UNNECESSARY  113
+#define OWERROR_HYGRO_STOP_MISSION_ERROR        114
+#define OWERROR_PORTNUM_ERROR                   115
+#define OWERROR_LEVEL_FAILED                    116
+#define OWERROR_PASSWORD_NOT_SET                117
+#define OWERROR_LATCH_NOT_SET                   118
+#define OWERROR_LIBUSB_OPEN_FAILED              119
+#define OWERROR_LIBUSB_DEVICE_ALREADY_OPENED    120
+#define OWERROR_LIBUSB_SET_CONFIGURATION_ERROR  121
+#define OWERROR_LIBUSB_CLAIM_INTERFACE_ERROR    122
+#define OWERROR_LIBUSB_SET_ALTINTERFACE_ERROR   123
+#define OWERROR_LIBUSB_NO_ADAPTER_FOUND         124
+
+/* One Wire functions defined in ownetu.c */
+SMALLINT  owFirst(int portnum, SMALLINT do_reset, SMALLINT alarm_only);
+SMALLINT  owNext(int portnum, SMALLINT do_reset, SMALLINT alarm_only);
+void      owSerialNum(int portnum, uchar *serialnum_buf, SMALLINT do_read);
+void      owFamilySearchSetup(int portnum, SMALLINT search_family);
+void      owSkipFamily(int portnum);
+SMALLINT  owAccess(int portnum);
+SMALLINT  owVerify(int portnum, SMALLINT alarm_only);
+SMALLINT  owOverdriveAccess(int portnum);
+
+
+/* external One Wire functions defined in owsesu.c */
+ SMALLINT owAcquire(int portnum, char *port_zstr);
+ int      owAcquireEx(const char *port_zstr);
+ void     owRelease(int portnum);
+
+/* external One Wire functions defined in findtype.c */
+/* SMALLINT FindDevices(int,uchar FamilySN[][8],SMALLINT,int); */
+
+/* external One Wire functions from link layer owllu.c */
+SMALLINT owTouchReset(int portnum);
+SMALLINT owTouchBit(int portnum, SMALLINT sendbit);
+SMALLINT owTouchByte(int portnum, SMALLINT sendbyte);
+SMALLINT owWriteByte(int portnum, SMALLINT sendbyte);
+SMALLINT owReadByte(int portnum);
+SMALLINT owSpeed(int portnum, SMALLINT new_speed);
+SMALLINT owLevel(int portnum, SMALLINT new_level);
+SMALLINT owProgramPulse(int portnum);
+SMALLINT owWriteBytePower(int portnum, SMALLINT sendbyte);
+SMALLINT owReadBytePower(int portnum);
+SMALLINT owHasPowerDelivery(int portnum);
+SMALLINT owHasProgramPulse(int portnum);
+SMALLINT owHasOverDrive(int portnum);
+SMALLINT owReadBitPower(int portnum, SMALLINT applyPowerResponse);
+/* external One Wire global from owllu.c */
+extern SMALLINT FAMILY_CODE_04_ALARM_TOUCHRESET_COMPLIANCE;
+
+/* external One Wire functions from transaction layer in owtrnu.c */
+SMALLINT owBlock(int portnum, SMALLINT do_reset, uchar *tran_buf, SMALLINT tran_len);
+SMALLINT owReadPacketStd(int portnum, SMALLINT do_access, int start_page, uchar *read_buf);
+SMALLINT owWritePacketStd(int portnum, int start_page, uchar *write_buf,
+                          SMALLINT write_len, SMALLINT is_eprom, SMALLINT crc_type);
+SMALLINT owProgramByte(int portnum, SMALLINT write_byte, int addr, SMALLINT write_cmd,
+                       SMALLINT crc_type, SMALLINT do_access);
+
+/* link functions */
+void      msDelay(int len);
+long      msGettick(void);
+
+/* ioutil.c functions prototypes */
+int  EnterString(char *msg, char *buf, int min, int max);
+int  EnterNum(char *msg, int numchars, long *value, long min, long max);
+int  EnterHex(char *msg, int numchars, ulong *value);
+int  ToHex(char ch);
+int  getkeystroke(void);
+int  key_abort(void);
+void ExitProg(char *msg, int exit_code);
+int  getData(uchar *write_buff, int max_len, SMALLINT gethex);
+void PrintHex(uchar* buffer, int cnt);
+void PrintChars(uchar* buffer, int cnt);
+void PrintSerialNum(uchar* buffer);
+
+/* external functions defined in crcutil.c */
+void setcrc16(int portnum, ushort reset);
+ushort docrc16(int portnum, ushort cdata);
+void setcrc8(int portnum, uchar reset);
+uchar docrc8(int portnum, uchar x);
+
+#endif /* OWNET_H */

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ibutton/ownetu.c
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ibutton/ownetu.c
@@ -1,0 +1,597 @@
+//---------------------------------------------------------------------------
+// Copyright (C) 2000 Dallas Semiconductor Corporation, All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY,  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL DALLAS SEMICONDUCTOR BE LIABLE FOR ANY CLAIM, DAMAGES
+// OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+//
+// Except as contained in this notice, the name of Dallas Semiconductor
+// shall not be used except as stated in the Dallas Semiconductor
+// Branding Policy.
+//---------------------------------------------------------------------------
+//
+//  owNetU.C - Network functions for 1-Wire Net devices
+//             using the DS2480/DS2480B (U) serial interface chip.
+//
+//  Version: 2.01
+//
+//           1.02 -> 1.03  Removed caps in #includes for Linux capatibility
+//           1.03 -> 2.00  Changed 'MLan' to 'ow'. Added support for
+//                         multiple ports.
+//          2.00 -> 2.01 Added error handling. Added circular-include check.
+//          2.01 -> 2.10 Added raw memory error handling and SMALLINT
+//          2.10 -> 3.00 Added memory bank functionality
+//                       Added file I/O operations
+//                       Updated search functions to be consistent with AN192
+//
+
+#include "ownet.h"
+#include "ds2480.h"
+
+// local functions defined in ownetu.c
+static SMALLINT bitacc(SMALLINT,SMALLINT,SMALLINT,uchar *);
+
+// global variables for this module to hold search state information
+static int LastDiscrepancy[MAX_PORTNUM];
+static int LastFamilyDiscrepancy[MAX_PORTNUM];
+static uchar LastDevice[MAX_PORTNUM];
+uchar SerialNum[MAX_PORTNUM][8];
+
+// external globals
+extern int UMode[MAX_PORTNUM];
+extern uchar USpeed[MAX_PORTNUM];
+
+//--------------------------------------------------------------------------
+// The 'owFirst' finds the first device on the 1-Wire Net  This function
+// contains one parameter 'alarm_only'.  When
+// 'alarm_only' is TRUE (1) the find alarm command 0xEC is
+// sent instead of the normal search command 0xF0.
+// Using the find alarm command 0xEC will limit the search to only
+// 1-Wire devices that are in an 'alarm' state.
+//
+// 'portnum'    - number 0 to MAX_PORTNUM-1.  This number is provided to
+//                indicate the symbolic port number.
+// 'do_reset'   - TRUE (1) perform reset before search, FALSE (0) do not
+//                perform reset before search.
+// 'alarm_only' - TRUE (1) the find alarm command 0xEC is
+//                sent instead of the normal search command 0xF0
+//
+// Returns:   TRUE (1) : when a 1-Wire device was found and it's
+//                       Serial Number placed in the global SerialNum
+//            FALSE (0): There are no devices on the 1-Wire Net.
+//
+SMALLINT owFirst(int portnum, SMALLINT do_reset, SMALLINT alarm_only)
+{
+   // reset the search state
+   LastDiscrepancy[portnum] = 0;
+   LastDevice[portnum] = FALSE;
+   LastFamilyDiscrepancy[portnum] = 0;
+
+   return owNext(portnum, do_reset, alarm_only);
+}
+
+//--------------------------------------------------------------------------
+// The 'owNext' function does a general search.  This function
+// continues from the previos search state. The search state
+// can be reset by using the 'owFirst' function.
+// This function contains one parameter 'alarm_only'.
+// When 'alarm_only' is TRUE (1) the find alarm command
+// 0xEC is sent instead of the normal search command 0xF0.
+// Using the find alarm command 0xEC will limit the search to only
+// 1-Wire devices that are in an 'alarm' state.
+//
+// 'portnum'    - number 0 to MAX_PORTNUM-1.  This number was provided to
+//                OpenCOM to indicate the port number.
+// 'do_reset'   - TRUE (1) perform reset before search, FALSE (0) do not
+//                perform reset before search.
+// 'alarm_only' - TRUE (1) the find alarm command 0xEC is
+//                sent instead of the normal search command 0xF0
+//
+// Returns:   TRUE (1) : when a 1-Wire device was found and it's
+//                       Serial Number placed in the global SerialNum
+//            FALSE (0): when no new device was found.  Either the
+//                       last search was the last device or there
+//                       are no devices on the 1-Wire Net.
+//
+SMALLINT owNext(int portnum, SMALLINT do_reset, SMALLINT alarm_only)
+{
+   uchar last_zero,pos;
+   uchar tmp_serial_num[8];
+   uchar readbuffer[20],sendpacket[40];
+   uchar i,sendlen=0;
+   uchar lastcrc8;
+
+   // if the last call was the last one
+   if (LastDevice[portnum])
+   {
+      // reset the search
+      LastDiscrepancy[portnum] = 0;
+      LastDevice[portnum] = FALSE;
+      LastFamilyDiscrepancy[portnum] = 0;
+      return FALSE;
+   }
+
+   // check if reset first is requested
+   if (do_reset)
+   {
+      // reset the 1-wire
+      // if there are no parts on 1-wire, return FALSE
+      if (!owTouchReset(portnum))
+      {
+         // reset the search
+         LastDiscrepancy[portnum] = 0;
+         LastFamilyDiscrepancy[portnum] = 0;
+         OWERROR(OWERROR_NO_DEVICES_ON_NET);
+         return FALSE;
+      }
+   }
+
+   // build the command stream
+   // call a function that may add the change mode command to the buff
+   // check if correct mode
+   if (UMode[portnum] != MODSEL_DATA)
+   {
+      UMode[portnum] = MODSEL_DATA;
+      sendpacket[sendlen++] = MODE_DATA;
+   }
+
+   // search command
+   if (alarm_only)
+      sendpacket[sendlen++] = 0xEC; // issue the alarming search command
+   else
+      sendpacket[sendlen++] = 0xF0; // issue the search command
+
+   // change back to command mode
+   UMode[portnum] = MODSEL_COMMAND;
+   sendpacket[sendlen++] = MODE_COMMAND;
+
+   // search mode on
+   sendpacket[sendlen++] = (uchar)(CMD_COMM | FUNCTSEL_SEARCHON | USpeed[portnum]);
+
+   // change back to data mode
+   UMode[portnum] = MODSEL_DATA;
+   sendpacket[sendlen++] = MODE_DATA;
+
+   // set the temp Last Descrep to none
+   last_zero = 0;
+
+   // add the 16 bytes of the search
+   pos = sendlen;
+   for (i = 0; i < 16; i++)
+      sendpacket[sendlen++] = 0;
+
+   // only modify bits if not the first search
+   if (LastDiscrepancy[portnum] != 0)
+   {
+      // set the bits in the added buffer
+      for (i = 0; i < 64; i++)
+      {
+         // before last discrepancy
+         if (i < (LastDiscrepancy[portnum] - 1))
+               bitacc(WRITE_FUNCTION,
+                   bitacc(READ_FUNCTION,0,i,&SerialNum[portnum][0]),
+                   (short)(i * 2 + 1),
+                   &sendpacket[pos]);
+         // at last discrepancy
+         else if (i == (LastDiscrepancy[portnum] - 1))
+                bitacc(WRITE_FUNCTION,1,
+                   (short)(i * 2 + 1),
+                   &sendpacket[pos]);
+         // after last discrepancy so leave zeros
+      }
+   }
+
+   // change back to command mode
+   UMode[portnum] = MODSEL_COMMAND;
+   sendpacket[sendlen++] = MODE_COMMAND;
+
+   // search OFF
+   sendpacket[sendlen++] = (uchar)(CMD_COMM | FUNCTSEL_SEARCHOFF | USpeed[portnum]);
+
+   // flush the buffers
+   FlushCOM(portnum);
+
+   // send the packet
+   if (WriteCOM(portnum,sendlen,sendpacket))
+   {
+      // read back the 1 byte response
+      if (ReadCOM(portnum,17,readbuffer) == 17)
+      {
+         // interpret the bit stream
+         for (i = 0; i < 64; i++)
+         {
+            // get the SerialNum bit
+            bitacc(WRITE_FUNCTION,
+                   bitacc(READ_FUNCTION,0,(short)(i * 2 + 1),&readbuffer[1]),
+                   i,
+                   &tmp_serial_num[0]);
+            // check LastDiscrepancy
+            if ((bitacc(READ_FUNCTION,0,(short)(i * 2),&readbuffer[1]) == 1) &&
+                (bitacc(READ_FUNCTION,0,(short)(i * 2 + 1),&readbuffer[1]) == 0))
+            {
+               last_zero = i + 1;
+               // check LastFamilyDiscrepancy
+               if (i < 8)
+                  LastFamilyDiscrepancy[portnum] = i + 1;
+            }
+         }
+
+         // do dowcrc
+         setcrc8(portnum,0);
+//         for (i = 0; i < 8; i++)
+//            lastcrc8 = docrc8(portnum,tmp_serial_num[i]);
+         // The above has been commented out for the DS28E04.  The
+         // below has been added to accomidate the valid CRC with the
+         // possible changing serial number values of the DS28E04.
+         for (i = 0; i < 8; i++)
+         {
+            if (((tmp_serial_num[0] & 0x7F) == 0x1C) && (i == 1))
+               lastcrc8 = docrc8(portnum,0x7F);
+            else            
+               lastcrc8 = docrc8(portnum,tmp_serial_num[i]);
+         }
+
+
+         // check results
+         if ((lastcrc8 != 0) || (LastDiscrepancy[portnum] == 63) || (tmp_serial_num[0] == 0))
+         {
+            // error during search
+            // reset the search
+            LastDiscrepancy[portnum] = 0;
+            LastDevice[portnum] = FALSE;
+            LastFamilyDiscrepancy[portnum] = 0;
+            OWERROR(OWERROR_SEARCH_ERROR);
+            return FALSE;
+         }
+         // successful search
+         else
+         {
+            // set the last discrepancy
+            LastDiscrepancy[portnum] = last_zero;
+
+            // check for last device 
+            if (LastDiscrepancy[portnum] == 0)
+               LastDevice[portnum] = TRUE;
+
+            // copy the SerialNum to the buffer
+            for (i = 0; i < 8; i++)
+               SerialNum[portnum][i] = tmp_serial_num[i];
+
+            // set the count
+            return TRUE;
+         }
+      }
+      else
+         OWERROR(OWERROR_READCOM_FAILED);
+   }
+   else
+      OWERROR(OWERROR_WRITECOM_FAILED);
+   
+   // an error occured so re-sync with DS2480
+   DS2480Detect(portnum);
+
+   // reset the search
+   LastDiscrepancy[portnum] = 0;
+   LastDevice[portnum] = FALSE;
+   LastFamilyDiscrepancy[portnum] = 0;
+
+   return FALSE;
+}
+
+//--------------------------------------------------------------------------
+// The 'owSerialNum' function either reads or sets the SerialNum buffer
+// that is used in the search functions 'owFirst' and 'owNext'.
+// This function contains two parameters, 'serialnum_buf' is a pointer
+// to a buffer provided by the caller.  'serialnum_buf' should point to
+// an array of 8 unsigned chars.  The second parameter is a flag called
+// 'do_read' that is TRUE (1) if the operation is to read and FALSE
+// (0) if the operation is to set the internal SerialNum buffer from
+// the data in the provided buffer.
+//
+// 'portnum'       - number 0 to MAX_PORTNUM-1.  This number was provided to
+//                   OpenCOM to indicate the port number.
+// 'serialnum_buf' - buffer to that contains the serial number to set
+//                   when do_read = FALSE (0) and buffer to get the serial
+//                   number when do_read = TRUE (1).
+// 'do_read'       - flag to indicate reading (1) or setting (0) the current
+//                   serial number.
+//
+void owSerialNum(int portnum, uchar *serialnum_buf, SMALLINT do_read)
+{
+   uchar i;
+
+   // read the internal buffer and place in 'serialnum_buf'
+   if (do_read)
+   {
+      for (i = 0; i < 8; i++)
+         serialnum_buf[i] = SerialNum[portnum][i];
+   }
+   // set the internal buffer from the data in 'serialnum_buf'
+   else
+   {
+      for (i = 0; i < 8; i++)
+         SerialNum[portnum][i] = serialnum_buf[i];
+   }
+}
+
+//--------------------------------------------------------------------------
+// Setup the search algorithm to find a certain family of devices
+// the next time a search function is called 'owNext'.
+//
+// 'portnum'       - number 0 to MAX_PORTNUM-1.  This number was provided to
+//                   OpenCOM to indicate the port number.
+// 'search_family' - family code type to set the search algorithm to find
+//                   next.
+//
+void owFamilySearchSetup(int portnum, SMALLINT search_family)
+{
+   uchar i;
+
+   // set the search state to find search_family type devices
+   SerialNum[portnum][0] = search_family;
+   for (i = 1; i < 8; i++)
+      SerialNum[portnum][i] = 0;
+   LastDiscrepancy[portnum] = 64;
+   LastFamilyDiscrepancy[portnum] = 0;
+   LastDevice[portnum] = FALSE;
+}
+
+//--------------------------------------------------------------------------
+// Set the current search state to skip the current family code.
+//
+// 'portnum'  - number 0 to MAX_PORTNUM-1.  This number was provided to
+//               OpenCOM to indicate the port number.
+//
+void owSkipFamily(int portnum)
+{
+   // set the Last discrepancy to last family discrepancy
+   LastDiscrepancy[portnum] = LastFamilyDiscrepancy[portnum];
+
+   // clear the last family discrpepancy
+   LastFamilyDiscrepancy[portnum] = 0;
+
+   // check for end of list
+   if (LastDiscrepancy[portnum] == 0)
+      LastDevice[portnum] = TRUE;
+}
+
+//--------------------------------------------------------------------------
+// The 'owAccess' function resets the 1-Wire and sends a MATCH Serial
+// Number command followed by the current SerialNum code. After this
+// function is complete the 1-Wire device is ready to accept device-specific
+// commands.
+//
+// 'portnum'  - number 0 to MAX_PORTNUM-1.  This number was provided to
+//              OpenCOM to indicate the port number.
+//
+// Returns:   TRUE (1) : reset indicates present and device is ready
+//                       for commands.
+//            FALSE (0): reset does not indicate presence or echos 'writes'
+//                       are not correct.
+//
+SMALLINT owAccess(int portnum)
+{
+   uchar sendpacket[9];
+   uchar i;
+
+   // reset the 1-wire
+   if (owTouchReset(portnum))
+   {
+      // create a buffer to use with block function
+      // match Serial Number command 0x55
+      sendpacket[0] = 0x55;
+      // Serial Number
+      for (i = 1; i < 9; i++)
+         sendpacket[i] = SerialNum[portnum][i-1];
+
+      // send/recieve the transfer buffer
+      if (owBlock(portnum,FALSE,sendpacket,9))
+      {
+         // verify that the echo of the writes was correct
+         for (i = 1; i < 9; i++)
+            if (sendpacket[i] != SerialNum[portnum][i-1])
+               return FALSE;
+
+         if (sendpacket[0] != 0x55)
+         {
+            OWERROR(OWERROR_WRITE_VERIFY_FAILED);
+            return FALSE;
+         }
+         else
+            return TRUE;
+      }
+      else
+         OWERROR(OWERROR_BLOCK_FAILED);
+   }
+   else
+      OWERROR(OWERROR_NO_DEVICES_ON_NET);
+
+   // reset or match echo failed
+   return FALSE;
+}
+
+//----------------------------------------------------------------------
+// The function 'owVerify' verifies that the current device
+// is in contact with the 1-Wire Net.
+// Using the find alarm command 0xEC will verify that the device
+// is in contact with the 1-Wire Net and is in an 'alarm' state.
+//
+// 'portnum'    - number 0 to MAX_PORTNUM-1.  This number was provided to
+//                OpenCOM to indicate the port number.
+// 'alarm_only' - TRUE (1) the find alarm command 0xEC
+//                         is sent instead of the normal search
+//                         command 0xF0.
+//
+// Returns:   TRUE (1) : when the 1-Wire device was verified
+//                       to be on the 1-Wire Net
+//                       with alarm_only == FALSE
+//                       or verified to be on the 1-Wire Net
+//                       AND in an alarm state when
+//                       alarm_only == TRUE.
+//            FALSE (0): the 1-Wire device was not on the
+//                       1-Wire Net or if alarm_only
+//                       == TRUE, the device may be on the
+//                       1-Wire Net but in a non-alarm state.
+//
+SMALLINT owVerify(int portnum, SMALLINT alarm_only)
+{
+   uchar i,sendlen=0,goodbits=0,cnt=0,s,tst;
+   uchar sendpacket[50];
+
+   // construct the search rom
+   if (alarm_only)
+      sendpacket[sendlen++] = 0xEC; // issue the alarming search command
+   else
+      sendpacket[sendlen++] = 0xF0; // issue the search command
+   // set all bits at first
+   for (i = 1; i <= 24; i++)
+      sendpacket[sendlen++] = 0xFF;
+   // now set or clear apropriate bits for search
+   for (i = 0; i < 64; i++)
+      bitacc(WRITE_FUNCTION,bitacc(READ_FUNCTION,0,i,&SerialNum[portnum][0]),(int)((i+1)*3-1),&sendpacket[1]);
+
+   // send/recieve the transfer buffer
+   if (owBlock(portnum,TRUE,sendpacket,sendlen))
+   {
+      // check results to see if it was a success
+      for (i = 0; i < 192; i += 3)
+      {
+         tst = (bitacc(READ_FUNCTION,0,i,&sendpacket[1]) << 1) |
+                bitacc(READ_FUNCTION,0,(int)(i+1),&sendpacket[1]);
+
+         s = bitacc(READ_FUNCTION,0,cnt++,&SerialNum[portnum][0]);
+
+         if (tst == 0x03)  // no device on line
+         {
+              goodbits = 0;    // number of good bits set to zero
+              break;     // quit
+         }
+
+         if (((s == 0x01) && (tst == 0x02)) ||
+             ((s == 0x00) && (tst == 0x01))    )  // correct bit
+            goodbits++;  // count as a good bit
+      }
+
+      // check too see if there were enough good bits to be successful
+      if (goodbits >= 8)
+         return TRUE;
+   }
+   else
+      OWERROR(OWERROR_BLOCK_FAILED);
+
+   // block fail or device not present
+   return FALSE;
+}
+
+//----------------------------------------------------------------------
+// Perform a overdrive MATCH command to select the 1-Wire device with
+// the address in the ID data register.
+//
+// 'portnum'  - number 0 to MAX_PORTNUM-1.  This number was provided to
+//               OpenCOM to indicate the port number.
+//
+// Returns:  TRUE: If the device is present on the 1-Wire Net and
+//                 can do overdrive then the device is selected.
+//           FALSE: Device is not present or not capable of overdrive.
+//
+//  *Note: This function could be converted to send DS2480
+//         commands in one packet.
+//
+SMALLINT owOverdriveAccess(int portnum)
+{
+   uchar sendpacket[8];
+   uchar i, bad_echo = FALSE;
+
+   // make sure normal level
+   owLevel(portnum,MODE_NORMAL);
+
+   // force to normal communication speed
+   owSpeed(portnum,MODE_NORMAL);
+
+   // call the 1-Wire Net reset function
+   if (owTouchReset(portnum))
+   {
+      // send the match command 0x69
+      if (owWriteByte(portnum,0x69))
+      {
+         // switch to overdrive communication speed
+         owSpeed(portnum,MODE_OVERDRIVE);
+
+         // create a buffer to use with block function
+         // Serial Number
+         for (i = 0; i < 8; i++)
+            sendpacket[i] = SerialNum[portnum][i];
+
+         // send/recieve the transfer buffer
+         if (owBlock(portnum,FALSE,sendpacket,8))
+         {
+            // verify that the echo of the writes was correct
+            for (i = 0; i < 8; i++)
+               if (sendpacket[i] != SerialNum[portnum][i])
+                  bad_echo = TRUE;
+            // if echo ok then success
+            if (!bad_echo)
+               return TRUE;
+            else
+               OWERROR(OWERROR_WRITE_VERIFY_FAILED);
+         }
+         else
+            OWERROR(OWERROR_BLOCK_FAILED);
+      }
+      else
+         OWERROR(OWERROR_WRITE_BYTE_FAILED);
+   }
+   else
+      OWERROR(OWERROR_NO_DEVICES_ON_NET);
+
+   // failure, force back to normal communication speed
+   owSpeed(portnum,MODE_NORMAL);
+
+   return FALSE;
+}
+
+//--------------------------------------------------------------------------
+// Bit utility to read and write a bit in the buffer 'buf'.
+//
+// 'op'    - operation (1) to set and (0) to read
+// 'state' - set (1) or clear (0) if operation is write (1)
+// 'loc'   - bit number location to read or write
+// 'buf'   - pointer to array of bytes that contains the bit
+//           to read or write
+//
+// Returns: 1   if operation is set (1)
+//          0/1 state of bit number 'loc' if operation is reading
+//
+static SMALLINT bitacc(SMALLINT op, SMALLINT state, SMALLINT loc, uchar *buf)
+{
+   SMALLINT nbyt,nbit;
+
+   nbyt = (loc / 8);
+   nbit = loc - (nbyt * 8);
+
+   if (op == WRITE_FUNCTION)
+   {
+      if (state)
+         buf[nbyt] |= (0x01 << nbit);
+      else
+         buf[nbyt] &= ~(0x01 << nbit);
+
+      return 1;
+   }
+   else
+      return ((buf[nbyt] >> nbit) & 0x01);
+}

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ibutton/owsesu.c
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ibutton/owsesu.c
@@ -1,0 +1,116 @@
+//---------------------------------------------------------------------------
+// Copyright (C) 2000 Dallas Semiconductor Corporation, All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY,  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL DALLAS SEMICONDUCTOR BE LIABLE FOR ANY CLAIM, DAMAGES
+// OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+//
+// Except as contained in this notice, the name of Dallas Semiconductor
+// shall not be used except as stated in the Dallas Semiconductor
+// Branding Policy.
+//---------------------------------------------------------------------------
+//
+//  owSesU.C - Acquire and release a Session on the 1-Wire Net.
+//
+//  Version: 2.01
+//
+//  History: 1.03 -> 2.00  Changed 'MLan' to 'ow'. Added support for
+//                         multiple ports.
+//          2.00 -> 2.01 Added error handling. Added circular-include check.
+//          2.01 -> 2.10 Added raw memory error handling and SMALLINT
+//          2.10 -> 3.00 Added memory bank functionality
+//                       Added file I/O operations
+//
+
+#include "ownet.h"
+#include "ds2480.h"
+
+//---------------------------------------------------------------------------
+// Attempt to acquire a 1-Wire net using a com port and a DS2480 based
+// adapter.
+//
+// 'portnum'    - number 0 to MAX_PORTNUM-1.  This number was provided to
+//                OpenCOM to indicate the port number.
+// 'port_zstr'  - zero terminated port name.  For this platform
+//                use format COMX where X is the port number.
+//
+// Returns: TRUE - success, COM port opened
+//
+// exportable functions defined in ownetu.c
+SMALLINT owAcquire(int portnum, char *port_zstr)
+{
+   // attempt to open the communications port
+   if (OpenCOM(portnum,port_zstr) < 0)
+   {
+      OWERROR(OWERROR_OPENCOM_FAILED);
+      return FALSE;
+   }
+
+   // detect DS2480
+   if (!DS2480Detect(portnum))
+   {
+      CloseCOM(portnum);
+      OWERROR(OWERROR_DS2480_NOT_DETECTED);
+      return FALSE;
+   }
+
+   return TRUE;
+}
+
+//---------------------------------------------------------------------------
+// Attempt to acquire a 1-Wire net using a com port and a DS2480 based
+// adapter.
+//
+// 'port_zstr'  - zero terminated port name.  For this platform
+//                use format COMX where X is the port number.
+//
+// Returns: valid handle, or -1 if an error occurred
+//
+// exportable functions defined in ownetu.c
+//
+int owAcquireEx(const char *port_zstr)
+{
+   int portnum;
+
+   // attempt to open the communications port
+   if ((portnum = OpenCOMEx(port_zstr)) < 0)
+   {
+      OWERROR(OWERROR_OPENCOM_FAILED);
+      return -1;
+   }
+
+   // detect DS2480
+   if (!DS2480Detect(portnum))
+   {
+      CloseCOM(portnum);
+      OWERROR(OWERROR_DS2480_NOT_DETECTED);
+      return -1;
+   }
+
+   return portnum;
+}
+
+//---------------------------------------------------------------------------
+// Release the previously acquired a 1-Wire net.
+//
+// 'portnum'    - number 0 to MAX_PORTNUM-1.  This number was provided to
+//                OpenCOM to indicate the port number.
+//
+void owRelease(int portnum)
+{
+   CloseCOM(portnum);
+}

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ibutton/owtrnu.c
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ibutton/owtrnu.c
@@ -1,0 +1,597 @@
+//---------------------------------------------------------------------------
+// Copyright (C) 2000 Dallas Semiconductor Corporation, All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY,  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL DALLAS SEMICONDUCTOR BE LIABLE FOR ANY CLAIM, DAMAGES
+// OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+//
+// Except as contained in this notice, the name of Dallas Semiconductor
+// shall not be used except as stated in the Dallas Semiconductor
+// Branding Policy.
+//---------------------------------------------------------------------------
+//
+//  owTranU.C - Transport functions for 1-Wire Net
+//              using the DS2480B (U) serial interface chip.
+//
+//  Version: 2.01
+//
+//  History: 1.02 -> 1.03  Removed caps in #includes for Linux capatibility
+//           1.03 -> 2.00  Changed 'MLan' to 'ow'. Added support for
+//                         multiple ports.
+//           2.00 -> 2.01  Added support for owError library
+//           2.01 -> 2.10  Added SMALLINT for small processors and error
+//                         handling plus the raw memory utilities.
+//           2.10 -> 3.00 Added memory bank functionality
+//                        Added file I/O operations
+//
+
+#include "ownet.h"
+#include "ds2480.h"
+// external defined in ds2480ut.c
+extern SMALLINT UBaud[MAX_PORTNUM];
+extern SMALLINT UMode[MAX_PORTNUM];
+extern SMALLINT USpeed[MAX_PORTNUM];
+extern uchar SerialNum[MAX_PORTNUM][8];
+
+// local static functions
+static SMALLINT Write_Scratchpad(int,uchar *,int,SMALLINT);
+static SMALLINT Copy_Scratchpad(int,int,SMALLINT);
+
+//--------------------------------------------------------------------------
+// The 'owBlock' transfers a block of data to and from the
+// 1-Wire Net with an optional reset at the begining of communication.
+// The result is returned in the same buffer.
+//
+// 'portnum'  - number 0 to MAX_PORTNUM-1.  This number is provided to
+//              indicate the symbolic port number.
+// 'do_reset' - cause a owTouchReset to occure at the begining of
+//              communication TRUE(1) or not FALSE(0)
+// 'tran_buf' - pointer to a block of unsigned
+//              chars of length 'tran_len' that will be sent
+//              to the 1-Wire Net
+// 'tran_len' - length in bytes to transfer
+
+// Supported devices: all
+//
+// Returns:   TRUE (1) : The optional reset returned a valid
+//                       presence (do_reset == TRUE) or there
+//                       was no reset required.
+//            FALSE (0): The reset did not return a valid prsence
+//                       (do_reset == TRUE).
+//
+//  The maximum tran_length is (160)
+//
+SMALLINT owBlock(int portnum, SMALLINT do_reset, uchar *tran_buf, SMALLINT tran_len)
+{
+   uchar sendpacket[320];
+   uchar sendlen=0, i;
+
+   // check for a block too big
+   if (tran_len > 160)
+   {
+      OWERROR(OWERROR_BLOCK_TOO_BIG);
+      return FALSE;
+   }
+
+   // check if need to do a owTouchReset first
+   if (do_reset)
+   {
+      if (!owTouchReset(portnum))
+      {
+         OWERROR(OWERROR_NO_DEVICES_ON_NET);
+         return FALSE;
+      }
+   }
+
+   // construct the packet to send to the DS2480
+   // check if correct mode
+   if (UMode[portnum] != MODSEL_DATA)
+   {
+      UMode[portnum] = MODSEL_DATA;
+      sendpacket[sendlen++] = MODE_DATA;
+   }
+
+   // add the bytes to send
+   for (i = 0; i < tran_len; i++)
+   {
+      sendpacket[sendlen++] = tran_buf[i];
+
+      // check for duplication of data that looks like COMMAND mode
+      if (tran_buf[i] == MODE_COMMAND)
+         sendpacket[sendlen++] = tran_buf[i];
+   }
+
+   // flush the buffers
+   FlushCOM(portnum);
+
+   // send the packet
+   if (WriteCOM(portnum,sendlen,sendpacket))
+   {
+      // read back the response
+      if (ReadCOM(portnum,tran_len,tran_buf) == tran_len)
+         return TRUE;
+      else
+         OWERROR(OWERROR_READCOM_FAILED);
+   }
+   else
+      OWERROR(OWERROR_WRITECOM_FAILED);
+
+   // an error occured so re-sync with DS2480
+   DS2480Detect(portnum);
+
+   return FALSE;
+}
+
+//--------------------------------------------------------------------------
+// Read a Universal Data Packet from a standard NVRAM iButton
+// and return it in the provided buffer. The page that the
+// packet resides on is 'start_page'.  Note that this function is limited
+// to single page packets. The buffer 'read_buf' must be at least
+// 29 bytes long.
+//
+// The Universal Data Packet always start on page boundaries but
+// can end anywhere.  The length is the number of data bytes not
+// including the length byte and the CRC16 bytes.  There is one
+// length byte. The CRC16 is first initialized to the starting
+// page number.  This provides a check to verify the page that
+// was intended is being read.  The CRC16 is then calculated over
+// the length and data bytes.  The CRC16 is then inverted and stored
+// low byte first followed by the high byte.
+//
+// Supported devices: DS1992, DS1993, DS1994, DS1995, DS1996, DS1982,
+//                    DS1985, DS1986, DS2407, and DS1971.
+//
+// 'portnum'    - number 0 to MAX_PORTNUM-1.  This number is provided to
+//                indicate the symbolic port number.
+// 'do_access'  - flag to indicate if an 'owAccess' should be
+//                peformed at the begining of the read.  This may
+//                be FALSE (0) if the previous call was to read the
+//                previous page (start_page-1).
+// 'start_page' - page number to start the read from
+// 'read_buf'   - pointer to a location to store the data read
+//
+// Returns:  >=0 success, number of data bytes in the buffer
+//           -1  failed to read a valid UDP
+//
+//
+SMALLINT owReadPacketStd(int portnum, SMALLINT do_access, int start_page, uchar *read_buf)
+{
+   uchar i,length,sendlen=0,head_len=0;
+   uchar sendpacket[50];
+   ushort lastcrc16;
+
+   // check if access header is done
+   // (only use if in sequention read with one access at begining)
+   if (do_access)
+   {
+      // match command
+      sendpacket[sendlen++] = 0x55;
+      for (i = 0; i < 8; i++)
+         sendpacket[sendlen++] = SerialNum[portnum][i];
+      // read memory command
+      sendpacket[sendlen++] = 0xF0;
+      // write the target address
+      sendpacket[sendlen++] = ((start_page << 5) & 0xFF);
+      sendpacket[sendlen++] = (start_page >> 3);
+      // check for DS1982 exception (redirection byte)
+      if (SerialNum[portnum][0] == 0x09)
+         sendpacket[sendlen++] = 0xFF;
+      // record the header length
+      head_len = sendlen;
+   }
+   // read the entire page length byte
+   for (i = 0; i < 32; i++)
+      sendpacket[sendlen++] = 0xFF;
+
+   // send/recieve the transfer buffer
+   if (owBlock(portnum,do_access,sendpacket,sendlen))
+   {
+      // seed crc with page number
+      setcrc16(portnum,(ushort)start_page);
+
+      // attempt to read UDP from sendpacket
+      length = sendpacket[head_len];
+      docrc16(portnum,(ushort)length);
+
+      // verify length is not too large
+      if (length <= 29)
+      {
+         // loop to read packet including CRC
+         for (i = 0; i < length; i++)
+         {
+             read_buf[i] = sendpacket[i+1+head_len];
+             docrc16(portnum,read_buf[i]);
+         }
+
+         // read and compute the CRC16
+         docrc16(portnum,sendpacket[i+1+head_len]);
+         lastcrc16 = docrc16(portnum,sendpacket[i+2+head_len]);
+
+         // verify the CRC16 is correct
+         if (lastcrc16 == 0xB001)
+           return length;        // return number of byte in record
+         else
+            OWERROR(OWERROR_CRC_FAILED);
+      }
+      else
+         OWERROR(OWERROR_INCORRECT_CRC_LENGTH);
+   }
+   else
+      OWERROR(OWERROR_BLOCK_FAILED);
+
+   // failed block or incorrect CRC
+   return -1;
+}
+
+//--------------------------------------------------------------------------
+// Write a Universal Data Packet onto a standard NVRAM 1-Wire device
+// on page 'start_page'.  This function is limited to UDPs that
+// fit on one page.  The data to write is provided as a buffer
+// 'write_buf' with a length 'write_len'.
+//
+// The Universal Data Packet always start on page boundaries but
+// can end anywhere.  The length is the number of data bytes not
+// including the length byte and the CRC16 bytes.  There is one
+// length byte. The CRC16 is first initialized to the starting
+// page number.  This provides a check to verify the page that
+// was intended is being read.  The CRC16 is then calculated over
+// the length and data bytes.  The CRC16 is then inverted and stored
+// low byte first followed by the high byte.
+//
+// Supported devices: is_eprom=0
+//                        DS1992, DS1993, DS1994, DS1995, DS1996
+//                    is_eprom=1, crc_type=0(CRC8)
+//                        DS1982
+//                    is_eprom=1, crc_type=1(CRC16)
+//                        DS1985, DS1986, DS2407
+//
+// 'portnum'    - number 0 to MAX_PORTNUM-1.  This number is provided to
+//                indicate the symbolic port number.
+// 'start_page' - page number to write packet to
+// 'write_buf'  - pointer to buffer containing data to write
+// 'write_len'  - number of data byte in write_buf
+// 'is_eprom'   - flag set if device is an EPROM (1 EPROM, 0 NVRAM)
+// 'crc_type'   - if is_eprom=1 then indicates CRC type
+//                (0 CRC8, 1 CRC16)
+//
+// Returns: TRUE(1)  success, packet written
+//          FALSE(0) failure to write, contact lost or device locked
+//
+SMALLINT owWritePacketStd(int portnum, int start_page, uchar *write_buf,
+                        SMALLINT write_len, SMALLINT is_eprom, SMALLINT crc_type)
+{
+   uchar construct_buffer[32];
+   uchar i,buffer_cnt=0,start_address,do_access;
+   ushort lastcrc16 = 0;
+
+   // check to see if data too long to fit on device
+   if (write_len > 29)
+     return FALSE;
+
+   // seed crc with page number
+   setcrc16(portnum,(ushort)start_page);
+
+   // set length byte
+   construct_buffer[buffer_cnt++] = (uchar)(write_len);
+   docrc16(portnum,(ushort)write_len);
+
+   // fill in the data to write
+   for (i = 0; i < write_len; i++)
+   {
+     lastcrc16 = docrc16(portnum,write_buf[i]);
+     construct_buffer[buffer_cnt++] = write_buf[i];
+   }
+
+   // add the crc
+   construct_buffer[buffer_cnt++] = (uchar)(~(lastcrc16 & 0xFF));
+   construct_buffer[buffer_cnt++] = (uchar)(~((lastcrc16 & 0xFF00) >> 8));
+
+   // check if not EPROM
+   if (!is_eprom)
+   {
+      // write the page
+      if (!Write_Scratchpad(portnum,construct_buffer,start_page,buffer_cnt))
+      {
+         OWERROR(OWERROR_WRITE_SCRATCHPAD_FAILED);
+         return FALSE;
+      }
+
+      // copy the scratchpad
+      if (!Copy_Scratchpad(portnum,start_page,buffer_cnt))
+      {
+         OWERROR(OWERROR_COPY_SCRATCHPAD_FAILED);
+         return FALSE;
+      }
+
+      // copy scratch pad was good then success
+      return TRUE;
+   }
+   // is EPROM
+   else
+   {
+      // calculate the start address
+      start_address = ((start_page >> 3) << 8) | ((start_page << 5) & 0xFF);
+      do_access = TRUE;
+      // loop to program each byte
+      for (i = 0; i < buffer_cnt; i++)
+      {
+         if (owProgramByte(portnum,construct_buffer[i], start_address + i,
+             0x0F, crc_type, do_access) != construct_buffer[i])
+         {
+            OWERROR(OWERROR_PROGRAM_BYTE_FAILED);
+            return FALSE;
+         }
+         do_access = FALSE;
+      }
+      return TRUE;
+   }
+}
+
+//--------------------------------------------------------------------------
+// Write a byte to an EPROM 1-Wire device.
+//
+// Supported devices: crc_type=0(CRC8)
+//                        DS1982
+//                    crc_type=1(CRC16)
+//                        DS1985, DS1986, DS2407
+//
+// 'portnum'    - number 0 to MAX_PORTNUM-1.  This number is provided to
+//                indicate the symbolic port number.
+// 'write_byte' - byte to program
+// 'addr'       - address of byte to program
+// 'write_cmd'  - command used to write (0x0F reg mem, 0x55 status)
+// 'crc_type'   - CRC used (0 CRC8, 1 CRC16)
+// 'do_access'  - Flag to access device for each byte
+//                (0 skip access, 1 do the access)
+//                WARNING, only use do_access=0 if programing the NEXT
+//                byte immediatly after the previous byte.
+//
+// Returns: >=0   success, this is the resulting byte from the program
+//                effort
+//          -1    error, device not connected or program pulse voltage
+//                not available
+//
+SMALLINT owProgramByte(int portnum, SMALLINT write_byte, int addr, SMALLINT write_cmd,
+                    SMALLINT crc_type, SMALLINT do_access)
+{
+   ushort lastcrc16;
+   uchar lastcrc8;
+
+   // optionally access the device
+   if (do_access)
+   {
+      if (!owAccess(portnum))
+      {
+         OWERROR(OWERROR_ACCESS_FAILED);
+         return -1;
+      }
+
+      // send the write command
+      if (!owWriteByte(portnum,write_cmd))
+      {
+         OWERROR(OWERROR_WRITE_BYTE_FAILED);
+         return -1;
+      }
+
+      // send the address
+      if (!owWriteByte(portnum,addr & 0xFF) || !owWriteByte(portnum,addr >> 8))
+      {
+         OWERROR(OWERROR_WRITE_BYTE_FAILED);
+         return -1;
+      }
+   }
+
+   // send the data to write
+   if (!owWriteByte(portnum,write_byte))
+   {
+      OWERROR(OWERROR_WRITE_BYTE_FAILED);
+      return -1;
+   }
+
+   // read the CRC
+   if (crc_type == 0)
+   {
+      // calculate CRC8
+      if (do_access)
+      {
+         setcrc8(portnum,0);
+         docrc8(portnum,(uchar)write_cmd);
+         docrc8(portnum,(uchar)(addr & 0xFF));
+         docrc8(portnum,(uchar)(addr >> 8));
+      }
+      else
+         setcrc8(portnum,(uchar)(addr & 0xFF));
+
+      docrc8(portnum,(uchar)write_byte);
+      // read and calculate the read crc
+      lastcrc8 = docrc8(portnum,(uchar)owReadByte(portnum));
+      // crc should now be 0x00
+      if (lastcrc8 != 0)
+      {
+         OWERROR(OWERROR_CRC_FAILED);
+         return -1;
+      }
+   }
+   else
+   {
+      // CRC16
+      if (do_access)
+      {
+         setcrc16(portnum,0);
+         docrc16(portnum,(ushort)write_cmd);
+         docrc16(portnum,(ushort)(addr & 0xFF));
+         docrc16(portnum,(ushort)(addr >> 8));
+      }
+      else
+         setcrc16(portnum,(ushort)addr);
+      docrc16(portnum,(ushort)write_byte);
+      // read and calculate the read crc
+      docrc16(portnum,(ushort)owReadByte(portnum));
+      lastcrc16 = docrc16(portnum,(ushort)owReadByte(portnum));
+      // crc should now be 0xB001
+      if (lastcrc16 != 0xB001)
+      {
+         OWERROR(OWERROR_CRC_FAILED);
+         return -1;
+      }
+   }
+
+   // send the program pulse
+   if (!owProgramPulse(portnum))
+   {
+      OWERROR(OWERROR_PROGRAM_PULSE_FAILED);
+      return -1;
+   }
+
+   // read back and return the resulting byte
+   return owReadByte(portnum);
+}
+
+//--------------------------------------------------------------------------
+// Write the scratchpad of a standard NVRam device such as the DS1992,3,4
+// and verify its contents.
+//
+// 'portnum'    - number 0 to MAX_PORTNUM-1.  This number is provided to
+//                indicate the symbolic port number.
+// 'write_buf'  - pointer to buffer containing data to write
+// 'start_page'    - page number to write packet to
+// 'write_len'  - number of data byte in write_buf
+//
+// Returns: TRUE(1)  success, the data was written and verified
+//          FALSE(0) failure, the data could not be written
+//
+//
+SMALLINT Write_Scratchpad(int portnum, uchar *write_buf, int start_page, SMALLINT write_len)
+{
+   uchar i,sendlen=0;
+   uchar sendpacket[50];
+
+   // match command
+   sendpacket[sendlen++] = 0x55;
+   for (i = 0; i < 8; i++)
+      sendpacket[sendlen++] = SerialNum[portnum][i];
+   // write scratchpad command
+   sendpacket[sendlen++] = 0x0F;
+   // write the target address
+   sendpacket[sendlen++] = ((start_page << 5) & 0xFF);
+   sendpacket[sendlen++] = (start_page >> 3);
+
+   // write packet bytes
+   for (i = 0; i < write_len; i++)
+      sendpacket[sendlen++] = write_buf[i];
+
+   // send/recieve the transfer buffer
+   if (owBlock(portnum,TRUE,sendpacket,sendlen))
+   {
+      // now attempt to read back to check
+      sendlen = 0;
+      // match command
+      sendpacket[sendlen++] = 0x55;
+      for (i = 0; i < 8; i++)
+         sendpacket[sendlen++] = SerialNum[portnum][i];
+      // read scratchpad command
+      sendpacket[sendlen++] = 0xAA;
+      // read the target address, offset and data
+      for (i = 0; i < (write_len + 3); i++)
+         sendpacket[sendlen++] = 0xFF;
+
+      // send/recieve the transfer buffer
+      if (owBlock(portnum,TRUE,sendpacket,sendlen))
+      {
+         // check address and offset of scratchpad read
+         if ((sendpacket[10] != ((start_page << 5) & 0xFF)) ||
+             (sendpacket[11] != (start_page >> 3)) ||
+             (sendpacket[12] != (write_len - 1)))
+         {
+            OWERROR(OWERROR_READ_VERIFY_FAILED);
+            return FALSE;
+         }
+
+         // verify each data byte
+         for (i = 0; i < write_len; i++)
+            if (sendpacket[i+13] != write_buf[i])
+            {
+               OWERROR(OWERROR_WRITE_VERIFY_FAILED);
+               return FALSE;
+            }
+
+         // must have verified
+         return TRUE;
+      }
+      else
+         OWERROR(OWERROR_BLOCK_FAILED);
+   }
+   else
+      OWERROR(OWERROR_BLOCK_FAILED);
+
+   // failed a block tranfer
+   return FALSE;
+}
+
+//--------------------------------------------------------------------------
+// Copy the contents of the scratchpad to its intended nv ram page.  The
+// page and length of the data is needed to build the authorization bytes
+// to copy.
+//
+// 'portnum'    - number 0 to MAX_PORTNUM-1.  This number is provided to
+//                indicate the symbolic port number.
+// 'start_page' - page number to write packet to
+// 'write_len'  - number of data bytes that are being copied
+//
+// Returns: TRUE(1)  success
+//          FALSE(0) failure
+//
+SMALLINT Copy_Scratchpad(int portnum, int start_page, SMALLINT write_len)
+{
+   uchar i,sendlen=0;
+   uchar sendpacket[50];
+
+   // match command
+   sendpacket[sendlen++] = 0x55;
+   for (i = 0; i < 8; i++)
+      sendpacket[sendlen++] = SerialNum[portnum][i];
+   // copy scratchpad command
+   sendpacket[sendlen++] = 0x55;
+   // write the target address
+   sendpacket[sendlen++] = ((start_page << 5) & 0xFF);
+   sendpacket[sendlen++] = (start_page >> 3);
+   sendpacket[sendlen++] = write_len - 1;
+   // read copy result
+   sendpacket[sendlen++] = 0xFF;
+
+   // send/recieve the transfer buffer
+   if (owBlock(portnum,TRUE,sendpacket,sendlen))
+   {
+      // check address and offset of scratchpad read
+      if ((sendpacket[10] != ((start_page << 5) & 0xFF)) ||
+          (sendpacket[11] != (start_page >> 3)) ||
+          (sendpacket[12] != (write_len - 1)) ||
+          (sendpacket[13] & 0xF0))
+      {
+         OWERROR(OWERROR_READ_VERIFY_FAILED);
+         return FALSE;
+      }
+      else
+         return TRUE;
+   }
+   else
+      OWERROR(OWERROR_BLOCK_FAILED);
+
+   // failed a block tranfer
+   return FALSE;
+}
+

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ibutton/sha18.c
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ibutton/sha18.c
@@ -1,0 +1,911 @@
+//---------------------------------------------------------------------------
+// Copyright (C) 2000 Dallas Semiconductor Corporation, All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY,  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL DALLAS SEMICONDUCTOR BE LIABLE FOR ANY CLAIM, DAMAGES
+// OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+//
+// Except as contained in this notice, the name of Dallas Semiconductor
+// shall not be used except as stated in the Dallas Semiconductor
+// Branding Policy.
+//---------------------------------------------------------------------------
+//
+// sha18.c - Low-level memory and SHA functions for the DS1963S.
+//
+// Version: 2.10
+//
+
+#include "ownet.h"
+#include "shaib.h"
+
+//--------------------------------------------------------------------------
+// Attempt to erase the scratchpad of the specified SHA iButton for DS1963S.
+//
+// 'portnum'     - number 0 to MAX_PORTNUM-1.  This number is provided to
+//                 indicate the symbolic port number.
+// 'address'     - value for TA2/TA1 (Note: TA2/TA1 aren't always set by
+//                 Erase Scratchpad command.)
+// 'resume'      - if true, device access is resumed using the RESUME
+//                 ROM command (0xA5).  Otherwise, a a MATCH ROM is
+//                 used along with the device's entire address number.
+//
+// Returns: TRUE, success, scratchpad erased
+//          FALSE, failure to erase scratchpad
+//
+SMALLINT EraseScratchpadSHA18(int portnum, int address, SMALLINT resume)
+{
+   uchar send_block[50];
+   int num_verf;
+   short send_cnt=0;
+
+   if(!resume)
+   {
+      // access the device
+      OWASSERT( SelectSHA(portnum), OWERROR_ACCESS_FAILED, FALSE );
+   }
+   else
+   {
+      // transmit RESUME command
+      send_block[send_cnt++] = ROM_CMD_RESUME;
+   }
+
+   // change number of verification bytes if in overdrive
+   num_verf = (in_overdrive[portnum&0x0FF]) ? 6 : 2;
+
+   // erase scratchpad command
+   send_block[send_cnt++] = CMD_ERASE_SCRATCHPAD;
+   // TA1
+   send_block[send_cnt++] = (uchar)(address & 0xFF);
+   // TA2
+   send_block[send_cnt++] = (uchar)((address >> 8) & 0xFF);
+
+   // now add the verification bytes
+   //for (i = 0; i < num_verf; i++)
+   //   send_block[send_cnt++] = 0xFF;
+   memset(&send_block[send_cnt], 0x0FF, num_verf);
+   send_cnt += num_verf;
+
+   // now send the block
+   OWASSERT( owBlock(portnum,resume,send_block,send_cnt),
+             OWERROR_BLOCK_FAILED, FALSE );
+
+   //\\//\\//\\//\\//\\//\\//\\//\\//\\//
+   #ifdef DEBUG_DUMP
+      debugout(send_block,send_cnt);
+   #endif
+   //\\//\\//\\//\\//\\//\\//\\//\\//\\//
+
+   // check verification
+   OWASSERT( ((send_block[send_cnt-1] & 0xF0) == 0x50) ||
+             ((send_block[send_cnt-1] & 0xF0) == 0xA0),
+             OWERROR_NO_COMPLETION_BYTE, FALSE);
+
+   return TRUE;
+}
+
+//----------------------------------------------------------------------
+// Read the scratchpad with CRC16 verification for DS1963S.
+//
+// 'portnum'     - number 0 to MAX_PORTNUM-1.  This number is provided to
+//                 indicate the symbolic port number.
+// 'address'     - pointer to address that is read from scratchpad
+// 'es'          - pointer to offset byte read from scratchpad
+// 'data'        - pointer data buffer read from scratchpad
+// 'resume'      - if true, device access is resumed using the RESUME
+//                 ROM command (0xA5).  Otherwise, a a MATCH ROM is
+//                 used along with the device's entire address number.
+//
+// Return: TRUE - scratch read, address, es, and data returned
+//         FALSE - error reading scratch, device not present
+//
+//
+SMALLINT ReadScratchpadSHA18(int portnum, int* address, uchar* es,
+                           uchar* data, SMALLINT resume)
+{
+   short send_cnt=0;
+   uchar send_block[40];
+   SMALLINT i;
+   ushort lastcrc16;
+   int bytes_read;
+
+   if(!resume)
+   {
+      // access the device
+      OWASSERT( SelectSHA(portnum), OWERROR_ACCESS_FAILED, FALSE );
+   }
+   else
+   {
+      // transmit RESUME command
+      send_block[send_cnt++] = ROM_CMD_RESUME;
+      resume = 1; // for addition later
+   }
+
+   // read scratchpad command
+   send_block[send_cnt++] = CMD_READ_SCRATCHPAD;
+
+   // now add the read bytes for data bytes and crc16
+   memset(&send_block[send_cnt], 0xff, 37);
+   send_cnt += 37;
+
+   // now send the block
+   OWASSERT( owBlock(portnum,resume,send_block,send_cnt),
+             OWERROR_BLOCK_FAILED, FALSE );
+
+   //\\//\\//\\//\\//\\//\\//\\//\\//\\//
+   #ifdef DEBUG_DUMP
+      debugout(send_block,send_cnt);
+   #endif
+   //\\//\\//\\//\\//\\//\\//\\//\\//\\//
+
+   bytes_read = (send_block[2+resume] << 8) | send_block[1+resume];
+   bytes_read = 32 - (bytes_read & 0x1F);
+
+   // calculate CRC16 of result
+   setcrc16(portnum,0);
+   for (i = resume; i < bytes_read + resume + 6; i++)
+      lastcrc16 = docrc16(portnum,send_block[i]);
+
+   // verify CRC16 is correct
+   OWASSERT( lastcrc16==0xB001, OWERROR_CRC_FAILED, FALSE );
+
+   // copy data to return buffers
+   if(address)
+      *address = (send_block[2+resume] << 8) | send_block[1+resume];
+   if(es)
+      *es = send_block[3+resume];
+
+   memcpy(data, &send_block[4+resume], 32);
+
+   // success
+   return TRUE;
+}
+
+//----------------------------------------------------------------------
+// Write the scratchpad with CRC16 verification for DS1963S.  The data
+// is padded until the offset is 0x1F so that the CRC16 is retrieved.
+//
+// 'portnum'     - number 0 to MAX_PORTNUM-1.  This number is provided to
+//                 indicate the symbolic port number.
+// 'address'     - address to write data to
+// 'data'        - data to write
+// 'data_len'    - number of bytes of data to write
+// 'resume'      - if true, device access is resumed using the RESUME
+//                 ROM command (0xA5).  Otherwise, a a MATCH ROM is
+//                 used along with the device's entire address number.
+//
+// Return: TRUE - write to scratch verified
+//         FALSE - error writing scratch, device not present, or HIDE
+//                 flag is in incorrect state for address being written.
+//
+SMALLINT WriteScratchpadSHA18(int portnum, int address, const uchar *data,
+                              SMALLINT data_len, SMALLINT resume)
+{
+   uchar send_block[50];
+   short send_cnt=0,i;
+   ushort lastcrc16;
+
+   if(!resume)
+   {
+      // access the device
+      OWASSERT( SelectSHA(portnum), OWERROR_ACCESS_FAILED, FALSE );
+   }
+   else
+   {
+      // transmit RESUME command
+      send_block[send_cnt++] = ROM_CMD_RESUME;
+   }
+
+   setcrc16(portnum,0);
+   // write scratchpad command
+   send_block[send_cnt] = CMD_WRITE_SCRATCHPAD;
+   lastcrc16 = docrc16(portnum,send_block[send_cnt++]);
+   // address 1
+   send_block[send_cnt] = (uchar)(address & 0xFF);
+   lastcrc16 = docrc16(portnum,send_block[send_cnt++]);
+   // address 2
+   send_block[send_cnt] = (uchar)((address >> 8) & 0xFF);
+   lastcrc16 = docrc16(portnum,send_block[send_cnt++]);
+   // data
+   for (i = 0; i < data_len; i++)
+   {
+      send_block[send_cnt] = data[i];
+      lastcrc16 = docrc16(portnum,send_block[send_cnt++]);
+   }
+   // pad if needed
+   for (i = 0; i < (0x1F - ((address + data_len - 1) & 0x1F)); i++)
+   {
+      send_block[send_cnt] = 0xFF;
+      lastcrc16 = docrc16(portnum,send_block[send_cnt++]);
+   }
+   // CRC16
+   send_block[send_cnt++] = 0xFF;
+   send_block[send_cnt++] = 0xFF;
+
+   // now send the block
+   OWASSERT( owBlock(portnum,resume,send_block,send_cnt),
+             OWERROR_BLOCK_FAILED, FALSE );
+
+   //\\//\\//\\//\\//\\//\\//\\//\\//\\//
+   #ifdef DEBUG_DUMP
+      debugout(send_block,send_cnt);
+   #endif
+   //\\//\\//\\//\\//\\//\\//\\//\\//\\//
+
+   // perform CRC16 of last 2 byte in packet
+   for (i = send_cnt - 2; i < send_cnt; i++)
+      lastcrc16 = docrc16(portnum,send_block[i]);
+
+   // verify CRC16 is correct
+   OWASSERT( lastcrc16==0xB001, OWERROR_CRC_FAILED, FALSE );
+
+   // success
+   return TRUE;
+}
+
+
+//----------------------------------------------------------------------
+// Copy the scratchpad with verification for DS1963S.  Assume that the
+// data was padded to get the CRC16 verification on write scratchpad.
+// This will result in the 'es' byte to be 0x1F.
+//
+// 'portnum'     - number 0 to MAX_PORTNUM-1.  This number is provided to
+//                 indicate the symbolic port number.
+// 'address'     - address of destination
+// 'len'         - length of data
+// 'resume'      - if true, device access is resumed using the RESUME
+//                 ROM command (0xA5).  Otherwise, a a MATCH ROM is
+//                 used along with the device's entire address number.
+//
+// Return: TRUE - copy scratch verified
+//         FALSE - error during copy scratch, device not present, or HIDE
+//                 flag is in incorrect state for address being written.
+//
+SMALLINT CopyScratchpadSHA18(int portnum, int address,
+                             SMALLINT len, SMALLINT resume)
+{
+   short send_cnt=0;
+   uchar send_block[10];
+   int num_verf;
+   uchar es = (address + len - 1) & 0x1F;
+
+   if(!resume)
+   {
+      // access the device
+      OWASSERT( SelectSHA(portnum), OWERROR_ACCESS_FAILED, FALSE );
+   }
+   else
+   {
+      // transmit RESUME command
+      send_block[send_cnt++] = ROM_CMD_RESUME;
+   }
+
+   // change number of verification bytes if in overdrive
+   num_verf = (in_overdrive[portnum&0x0FF]) ? 4 : 2;
+
+   // copy scratchpad command
+   send_block[send_cnt++] = CMD_COPY_SCRATCHPAD;
+   // address 1
+   send_block[send_cnt++] = (uchar)(address & 0xFF);
+   // address 2
+   send_block[send_cnt++] = (uchar)((address >> 8) & 0xFF);
+   // es
+   send_block[send_cnt++] = es;
+
+   // verification bytes
+   memset(&send_block[send_cnt], 0x0FF, num_verf);
+   send_cnt += num_verf;
+
+   // now send the block
+   OWASSERT( owBlock(portnum,resume,send_block,send_cnt),
+             OWERROR_BLOCK_FAILED, FALSE );
+
+   //\\//\\//\\//\\//\\//\\//\\//\\//\\//
+   #ifdef DEBUG_DUMP
+      debugout(send_block,send_cnt);
+   #endif
+   //\\//\\//\\//\\//\\//\\//\\//\\//\\//
+
+   // check verification
+   OWASSERT( ((send_block[send_cnt-1] & 0xF0) == 0x50) ||
+             ((send_block[send_cnt-1] & 0xF0) == 0xA0),
+             OWERROR_NO_COMPLETION_BYTE, FALSE );
+
+   return TRUE;
+}
+
+//----------------------------------------------------------------------
+// Perform a scratchpad match using provided data. Fixed data length
+// of 20 bytes.
+//
+// 'portnum'     - number 0 to MAX_PORTNUM-1.  This number is provided to
+//                 indicate the symbolic port number.
+// 'data'        - data to use in match scratch operation
+// 'resume'      - if true, device access is resumed using the RESUME
+//                 ROM command (0xA5).  Otherwise, a a MATCH ROM is
+//                 used along with the device's entire address number.
+//
+// Return: TRUE - valid match
+//         FALSE - no match or device not present
+//
+SMALLINT MatchScratchpadSHA18(int portnum, uchar* data, SMALLINT resume)
+{
+   short send_cnt=0;
+   uchar send_block[50];
+   int i;
+   ushort lastcrc16;
+
+   if(!resume)
+   {
+      // access the device
+      OWASSERT( SelectSHA(portnum), OWERROR_ACCESS_FAILED, FALSE );
+   }
+   else
+   {
+      // transmit RESUME command
+      send_block[send_cnt++] = ROM_CMD_RESUME;
+   }
+
+   setcrc16(portnum,0);
+   // match scratchpad command
+   send_block[send_cnt] = CMD_MATCH_SCRATCHPAD;
+   lastcrc16 = docrc16(portnum,send_block[send_cnt++]);
+
+   // send 20 data bytes
+   for (i = 0; i < 20; i++)
+   {
+      send_block[send_cnt] = data[i];
+      lastcrc16 = docrc16(portnum,send_block[send_cnt++]);
+   }
+   // send two crc bytes and verification byte
+   //for (i = 0; i < 3; i++)
+   //   send_block[send_cnt++] = 0xFF;
+   memset(&send_block[send_cnt], 0x0FF, 3);
+   send_cnt += 3;
+
+   // now send the block
+   OWASSERT( owBlock(portnum,resume,send_block,send_cnt),
+             OWERROR_BLOCK_FAILED, FALSE );
+
+   //\\//\\//\\//\\//\\//\\//\\//\\//\\//
+   #ifdef DEBUG_DUMP
+      debugout(send_block,send_cnt);
+   #endif
+   //\\//\\//\\//\\//\\//\\//\\//\\//\\//
+
+   // check the CRC
+   for (i = (send_cnt - 3); i < (send_cnt - 1); i++)
+      lastcrc16 = docrc16(portnum,send_block[i]);
+
+   // verify CRC16 is correct
+   OWASSERT( lastcrc16==0xB001, OWERROR_CRC_FAILED, FALSE );
+
+   // check verification
+   if(send_block[send_cnt - 1] != (uchar)0xFF)
+      return TRUE;
+   else
+      return FALSE;
+}
+
+//----------------------------------------------------------------------
+// Read Memory Page for DS1963S.
+//
+// 'portnum'     - number 0 to MAX_PORTNUM-1.  This number is provided to
+//                 indicate the symbolic port number.
+// 'pagenum'     - page number to do a read authenticate
+// 'data'        - buffer to read into from page
+// 'resume'      - if true, device access is resumed using the RESUME
+//                 ROM command (0xA5).  Otherwise, a a MATCH ROM is
+//                 used along with the device's entire address number.
+//
+// Return: TRUE - Read successfull
+//         FALSE - error occurred during read.
+//
+SMALLINT ReadMemoryPageSHA18(int portnum, SMALLINT pagenum,
+						   uchar* data, SMALLINT resume)
+{
+   short send_cnt=0;
+   uchar send_block[36];
+   int address = pagenum << 5;
+
+   if(!resume)
+   {
+      // access the device
+      OWASSERT( SelectSHA(portnum), OWERROR_ACCESS_FAILED, -1 );
+   }
+   else
+   {
+      // transmit RESUME command
+      send_block[send_cnt++] = ROM_CMD_RESUME;
+   }
+
+   // create the send block
+   // Read Memory command
+   send_block[send_cnt++] = CMD_READ_MEMORY;
+   // TA1
+   send_block[send_cnt++] = (uchar)(address & 0xFF);
+   // TA2
+   send_block[send_cnt++] = (uchar)((address >> 8) & 0xFF);
+
+   // now add the read bytes for data bytes
+   memset(&send_block[send_cnt], 0x0FF, 32);
+   send_cnt += 32;
+
+   // now send the block
+   OWASSERT( owBlock(portnum,TRUE,send_block,send_cnt),
+             OWERROR_BLOCK_FAILED, FALSE );
+
+   // transfer the results
+   memcpy(data, &send_block[send_cnt-32], 32);
+
+   return TRUE;
+}
+
+//----------------------------------------------------------------------
+// Read Authenticated Page for DS1963S.
+//
+// 'portnum'     - number 0 to MAX_PORTNUM-1.  This number is provided to
+//                 indicate the symbolic port number.
+// 'pagenum'     - page number to do a read authenticate
+// 'data'        - buffer to read into from page
+// 'sign'        - buffer for storing sha computation
+// 'resume'      - if true, device access is resumed using the RESUME
+//                 ROM command (0xA5).  Otherwise, a a MATCH ROM is
+//                 used along with the device's entire address number.
+//
+// Return: Value of write cycle counter for the page
+//         -1 for error
+//
+int ReadAuthPageSHA18(int portnum, SMALLINT pagenum, uchar* data,
+                    uchar* sign, SMALLINT resume)
+{
+   short send_cnt=0;
+   uchar send_block[56];
+   short num_verf;
+   SMALLINT i;
+   ushort lastcrc16;
+   int address = pagenum*32, wcc = -1;
+
+   if(!resume)
+   {
+      // access the device
+      OWASSERT( SelectSHA(portnum), OWERROR_ACCESS_FAILED, -1 );
+   }
+   else
+   {
+      // transmit RESUME command
+      send_block[send_cnt++] = ROM_CMD_RESUME;
+   }
+
+   //seed the crc
+   setcrc16(portnum,0);
+
+   // change number of verification bytes if in overdrive
+   num_verf = (in_overdrive[portnum&0x0FF]) ? 10 : 2;
+
+   // create the send block
+   // Read Authenticated Page command
+   send_block[send_cnt] = CMD_READ_AUTH_PAGE;
+   lastcrc16 = docrc16(portnum, send_block[send_cnt++]);
+
+   // TA1
+   send_block[send_cnt] = (uchar)(address & 0xFF);
+   lastcrc16 = docrc16(portnum,send_block[send_cnt++]);
+
+   // TA2
+   send_block[send_cnt] = (uchar)((address >> 8) & 0xFF);
+   lastcrc16 = docrc16(portnum,send_block[send_cnt++]);
+
+   // now add the read bytes for data bytes, counter, and crc16, verification
+   //for (i = 0; i < (42 + num_verf); i++)
+   //   send_block[send_cnt++] = 0xFF;
+   memset(&send_block[send_cnt], 0x0FF, 42+num_verf);
+   send_cnt += 42+num_verf;
+
+   // now send the block
+   OWASSERT( owBlock(portnum,resume,send_block,send_cnt),
+             OWERROR_BLOCK_FAILED, -1 );
+
+   //\\//\\//\\//\\//\\//\\//\\//\\//\\//
+   #ifdef DEBUG_DUMP
+      debugout(send_block,send_cnt);
+   #endif
+   //\\//\\//\\//\\//\\//\\//\\//\\//\\//
+
+   // check the CRC
+   for (i = resume?4:3; i < (send_cnt - num_verf); i++)
+      lastcrc16 = docrc16(portnum,send_block[i]);
+
+   // verify CRC16 is correct
+   OWASSERT( lastcrc16==0xB001, OWERROR_CRC_FAILED, -1);
+
+   // check verification
+   OWASSERT( ((send_block[send_cnt-1] & 0xF0) == 0x50) ||
+             ((send_block[send_cnt-1] & 0xF0) == 0xA0),
+             OWERROR_NO_COMPLETION_BYTE, -1);
+
+   // transfer results
+   //cnt = 0;
+   //for (i = send_cnt - 42 - num_verf; i < (send_cnt - 10 - num_verf); i++)
+   //   data[cnt++] = send_block[i];
+   memcpy(data, &send_block[send_cnt-42-num_verf], 32);
+
+   wcc = BytesToInt(&send_block[send_cnt-10-num_verf], 4);
+
+   if(sign!=NULL)
+   {
+      OWASSERT( ReadScratchpadSHA18(portnum, 0, 0, send_block, TRUE),
+                OWERROR_READ_SCRATCHPAD_FAILED, FALSE );
+
+      //for(i=0; i<20; i++)
+      //   sign[i] = send_block[i+8];
+      memcpy(sign, &send_block[8], 20);
+   }
+
+   return wcc;
+}
+
+//----------------------------------------------------------------------
+// Write Data Page for DS1963S.
+//
+// 'portnum'     - number 0 to MAX_PORTNUM-1.  This number is provided to
+//                 indicate the symbolic port number.
+// 'pagenum'     - page number to write to
+// 'data'        - buffer to write into page
+// 'resume'      - if true, device access is resumed using the RESUME
+//                 ROM command (0xA5).  Otherwise, a a MATCH ROM is
+//                 used along with the device's entire address number.
+//
+// Return: TRUE - Write successfull
+//         FALSE - error occurred during write.
+//
+SMALLINT WriteDataPageSHA18(int portnum, SMALLINT pagenum,
+                          uchar* data, SMALLINT resume)
+{
+   uchar buffer[32];
+   int addr = pagenum << 5, addr_buff;
+   uchar es = 0;
+
+   OWASSERT( EraseScratchpadSHA18(portnum, addr, resume),
+             OWERROR_ERASE_SCRATCHPAD_FAILED, FALSE );
+
+   OWASSERT( WriteScratchpadSHA18(portnum, addr, data, 32, TRUE),
+              OWERROR_WRITE_SCRATCHPAD_FAILED, FALSE );
+
+   OWASSERT( ReadScratchpadSHA18(portnum, &addr_buff, &es, buffer, TRUE),
+             OWERROR_READ_SCRATCHPAD_FAILED, FALSE );
+
+   // verify that what we read is exactly what we wrote
+   OWASSERT( (addr == addr_buff) && (es == 0x1F)
+                 && (memcmp(buffer, data, 32)==0),
+             OWERROR_READ_SCRATCHPAD_FAILED, FALSE );
+
+   OWASSERT( CopyScratchpadSHA18(portnum, addr, 32, TRUE),
+             OWERROR_COPY_SCRATCHPAD_FAILED, FALSE );
+
+   return TRUE;
+
+}
+
+//----------------------------------------------------------------------
+// Compute sha command based on control_byte and page address.
+//
+// 'portnum'      - number 0 to MAX_PORTNUM-1.  This number is provided to
+//                  indicate the symbolic port number.
+// 'control_byte' - control byte used in sha operation
+// 'address'      - address used in compute sha operation
+// 'resume'       - if true, device access is resumed using the RESUME
+//                  ROM command (0xA5).  Otherwise, a a MATCH ROM is
+//                  used along with the device's entire address number.
+//
+// Return: TRUE - compute sha finished
+//         FALSE - CRC error, device not present
+//
+SMALLINT SHAFunction18(int portnum, uchar control_byte,
+                    int address, SMALLINT resume)
+{
+   short send_cnt=0;
+   uchar send_block[18];
+   int i,num_verf;
+   ushort lastcrc16;
+
+   if(!resume)
+   {
+      // access the device
+      OWASSERT( SelectSHA(portnum), OWERROR_ACCESS_FAILED, FALSE );
+   }
+   else
+   {
+      // transmit RESUME command
+      send_block[send_cnt++] = ROM_CMD_RESUME;
+   }
+
+   setcrc16(portnum,0);
+   // change number of verification bytes if in overdrive
+   num_verf = (in_overdrive[portnum&0x0FF]) ? 10 : 2;
+
+   // Compute SHA Command
+   send_block[send_cnt] = CMD_COMPUTE_SHA;
+   lastcrc16 = docrc16(portnum,send_block[send_cnt++]);
+   // address 1
+   send_block[send_cnt] = (uchar)(address & 0xFF);
+   lastcrc16 = docrc16(portnum,send_block[send_cnt++]);
+   // address 2
+   send_block[send_cnt] = (uchar)((address >> 8) & 0xFF);
+   lastcrc16 = docrc16(portnum,send_block[send_cnt++]);
+   // control byte
+   send_block[send_cnt] = control_byte;
+   lastcrc16 = docrc16(portnum,send_block[send_cnt++]);
+
+   // now read bytes crc16, and verification
+   //for (i = 0; i < 2 + num_verf; i++)
+   //   send_block[send_cnt++] = 0xFF;
+   memset(&send_block[send_cnt], 0x0FF, 2+num_verf);
+   send_cnt += 2+num_verf;
+
+   // now send the block
+   OWASSERT( owBlock(portnum,resume,send_block,send_cnt),
+             OWERROR_BLOCK_FAILED, FALSE );
+
+   //\\//\\//\\//\\//\\//\\//\\//\\//\\//
+   #ifdef DEBUG_DUMP
+      debugout(send_block,send_cnt);
+   #endif
+   //\\//\\//\\//\\//\\//\\//\\//\\//\\//
+
+   // check the CRC
+   for (i = resume?5:4; i < (send_cnt - num_verf); i++)
+      lastcrc16 = docrc16(portnum,send_block[i]);
+
+   // verify CRC16 is correct
+   OWASSERT( lastcrc16==0xB001, OWERROR_CRC_FAILED, FALSE );
+
+   // check verification
+   OWASSERT( ((send_block[send_cnt-1] & 0xF0) == 0x50) ||
+             ((send_block[send_cnt-1] & 0xF0) == 0xA0),
+             OWERROR_NO_COMPLETION_BYTE, FALSE );
+
+   return TRUE;
+}
+
+//----------------------------------------------------------------------
+// Copies hidden scratchpad data into specified secret.  Resume command
+// is used by default.
+//
+// 'portnum'      - number 0 to MAX_PORTNUM-1.  This number is provided to
+//                  indicate the symbolic port number.
+// 'secretnum'    - secret number to replace with scratchpad data.
+//
+// Return: TRUE - copy secret succeeded
+//         FALSE - error or device not present
+//
+SMALLINT CopySecretSHA18(int portnum, SMALLINT secretnum)
+{
+   // change number of verification bytes if in overdrive
+   SMALLINT num_verf = (in_overdrive[portnum&0x0FF]) ? 10 : 2;
+
+   // each page has 4 secrets, so look at 2 LS bits to
+   // determine offset in the page.
+   SMALLINT secret_offset = (secretnum&3) << 3;
+
+   // secrets 0-3 are stored starting at address 0200h
+   // and 4-7 are stored starting at address 0220h.
+   int address = (secretnum<4 ? 0x0200 : 0x0220)
+                 + secret_offset;
+
+   SMALLINT length = 32 - secret_offset;
+   SMALLINT send_cnt = 0, i;
+   uchar send_block[38];
+   ushort lastcrc16;
+
+   //Since other functions must be called before this one
+   //that are communicating with the button, resume is assumed.
+   send_block[send_cnt++] = ROM_CMD_RESUME;
+   send_block[send_cnt++] = CMD_WRITE_SCRATCHPAD;
+   send_block[send_cnt++] = (uchar)address;
+   send_block[send_cnt++] = (uchar)(address>>8);
+
+   //for(i=0; i<length+2; i++)
+   //   send_block[send_cnt++] = (uchar)0x0FF;
+   memset(&send_block[send_cnt], 0x0FF, 2+length);
+   send_cnt += 2+length;
+
+
+   // now send the block
+   OWASSERT( owBlock(portnum,TRUE,send_block,send_cnt),
+             OWERROR_BLOCK_FAILED, FALSE );
+
+   //\\//\\//\\//\\//\\//\\//\\//\\//\\//
+   #ifdef DEBUG_DUMP
+      debugout(send_block,send_cnt);
+   #endif
+   //\\//\\//\\//\\//\\//\\//\\//\\//\\//
+
+   // calculate CRC16 of result
+   setcrc16(portnum,0);
+   for (i = 1; i < send_cnt ; i++)
+      lastcrc16 = docrc16(portnum,send_block[i]);
+
+   // verify CRC16 is correct
+   OWASSERT( lastcrc16==0xB001, OWERROR_CRC_FAILED, FALSE );
+
+   // Now read TA1/TA2 and ES, but not rest of data;
+   send_cnt = 1;
+   send_block[send_cnt++] = CMD_READ_SCRATCHPAD;
+
+   //for(i=0; i<3; i++)
+   //   send_block[send_cnt++] = (uchar)0x0FF;
+   memset(&send_block[send_cnt], 0x0FF, 3);
+   send_cnt += 3;
+
+   // now send the block to get TA1/TA2 and ES
+   OWASSERT( owBlock(portnum,TRUE,send_block,send_cnt),
+             OWERROR_BLOCK_FAILED, FALSE );
+
+   //\\//\\//\\//\\//\\//\\//\\//\\//\\//
+   #ifdef DEBUG_DUMP
+      debugout(send_block,send_cnt);
+   #endif
+   //\\//\\//\\//\\//\\//\\//\\//\\//\\//
+
+   // Use the same buffer to call copyScratchpad with proper
+   // authorization bytes.
+   send_block[1] = CMD_COPY_SCRATCHPAD;
+
+   //for(i=0; i<num_verf; i++)
+   //   send_block[send_cnt++] = (uchar)0x0FF;
+   memset(&send_block[send_cnt], 0x0FF, num_verf);
+   send_cnt += num_verf;
+
+   // now send the block
+   OWASSERT( owBlock(portnum,TRUE,send_block,send_cnt),
+             OWERROR_BLOCK_FAILED, FALSE );
+
+   //\\//\\//\\//\\//\\//\\//\\//\\//\\//
+   #ifdef DEBUG_DUMP
+      debugout(send_block,send_cnt);
+   #endif
+   //\\//\\//\\//\\//\\//\\//\\//\\//\\//
+
+   // check verification
+   OWASSERT( ((send_block[send_cnt-1] & 0xF0) == 0x50) ||
+             ((send_block[send_cnt-1] & 0xF0) == 0xA0),
+             OWERROR_NO_COMPLETION_BYTE, FALSE );
+
+   return TRUE;
+}
+
+//----------------------------------------------------------------------
+// Installs new system secret for DS1931S.  input_secret must be
+// divisible by 47.  Then, each block of 47 is split up with 32 bytes
+// written to a data page and 15 bytes are written to the scratchpad.
+// Then, Compute first secret is called (or compute next if the secret
+// is divisible by 47 more than once).
+//
+// 'portnum'       - number 0 to MAX_PORTNUM-1.  This number is provided to
+//                   indicate the symbolic port number.
+// 'pagenum'       - page number to do a read authenticate
+// 'secretnum'     - destination secret for computation results
+// 'input_secret'  - the input secret buffer used.
+// 'secret_length' - the length of the input secret buffer, divisibly
+//                   by 47.
+// 'resume'        - if true, device access is resumed using the RESUME
+//                   ROM command (0xA5).  Otherwise, a a MATCH ROM is
+//                   used along with the device's entire address number.
+//
+// Return: TRUE - Install successfull
+//         FALSE - error occurred during secret installation.
+//
+SMALLINT InstallSystemSecret18(int portnum, SMALLINT pagenum,
+                               SMALLINT secretnum, uchar* secret,
+                               int secret_length, SMALLINT resume)
+{
+   int addr = pagenum << 5;
+   int offset = 0, bytes_left = 0;
+   uchar data[32],scratchpad[32];
+
+   for(offset=0; offset<secret_length; offset+=47)
+   {
+      // clear the buffer
+      memset(data, 0x0FF, 32);
+      memset(scratchpad, 0x0FF, 32);
+
+      // Determine the amount of bytes remaining to be installed.
+      bytes_left = secret_length - offset;
+
+      // copy secret data into page buffer and scratchpad buffer
+      memcpy(data, &secret[offset], (bytes_left<32?bytes_left:32));
+      if(bytes_left>32)
+      {
+         memcpy(&scratchpad[8], &secret[offset+32],
+                (bytes_left<47?bytes_left-32:15));
+      }
+
+      // write secret data into data page
+      OWASSERT( WriteDataPageSHA18(portnum, pagenum, data, resume),
+                 OWERROR_WRITE_DATA_PAGE_FAILED, FALSE );
+
+      // write secret data into scratchpad
+      OWASSERT( WriteScratchpadSHA18(portnum, addr, scratchpad, 32, TRUE),
+                 OWERROR_WRITE_SCRATCHPAD_FAILED, FALSE );
+
+      // perform secret computation
+      OWASSERT( SHAFunction18(portnum,
+                 (uchar)(offset==0 ? SHA_COMPUTE_FIRST_SECRET
+                                   : SHA_COMPUTE_NEXT_SECRET), addr, TRUE),
+                OWERROR_SHA_FUNCTION_FAILED, FALSE );
+
+      // copy the resulting secret into secret location
+      OWASSERT( CopySecretSHA18(portnum, secretnum),
+                OWERROR_COPY_SECRET_FAILED, FALSE);
+
+      resume = TRUE;
+   }
+
+   return TRUE;
+}
+
+//----------------------------------------------------------------------
+// Binds unique secret to DS1963S.  bindData must be 32 bytes and
+// bindCode must be 15 bytes.
+//
+// 'portnum'       - number 0 to MAX_PORTNUM-1.  This number is provided to
+//                   indicate the symbolic port number.
+// 'pagenum'       - page number to do a read authenticate
+// 'secretnum'     - destination secret for computation results
+// 'bindData'      - the input data written to the data page for unique
+//                   secret computation.
+// 'bindCode'      - the input data written to the scratchpad for unique
+//                   secret computation.
+// 'resume'        - if true, device access is resumed using the RESUME
+//                   ROM command (0xA5).  Otherwise, a a MATCH ROM is
+//                   used along with the device's entire address number.
+//
+// Return: TRUE - bind successfull
+//         FALSE - error occurred during secret installation.
+//
+SMALLINT BindSecretToiButton18(int portnum, SMALLINT pagenum,
+                               SMALLINT secretnum,
+                               uchar* bindData, uchar* bindCode,
+                               SMALLINT resume)
+{
+   int addr = pagenum << 5;
+   uchar scratchpad[32];
+
+   memset(scratchpad, 0x00, 32);
+   memcpy(&scratchpad[8], bindCode, 15);
+
+   // write secret data into data page
+   OWASSERT( WriteDataPageSHA18(portnum, pagenum, bindData, resume),
+              OWERROR_WRITE_DATA_PAGE_FAILED, FALSE );
+
+   // write secret data into scratchpad
+   OWASSERT( WriteScratchpadSHA18(portnum, addr, scratchpad, 32, TRUE),
+              OWERROR_WRITE_SCRATCHPAD_FAILED, FALSE );
+
+   // perform secret computation
+   OWASSERT( SHAFunction18(portnum, (uchar)SHA_COMPUTE_NEXT_SECRET,
+                         addr, TRUE),
+             OWERROR_SHA_FUNCTION_FAILED, FALSE );
+
+   // copy the resulting secret into secret location
+   OWASSERT( CopySecretSHA18(portnum, secretnum),
+             OWERROR_COPY_SECRET_FAILED, FALSE);
+
+   return TRUE;
+}
+
+

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ibutton/shaib.c
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ibutton/shaib.c
@@ -1,0 +1,674 @@
+/*---------------------------------------------------------------------------
+ * Copyright (C) 2000 Dallas Semiconductor Corporation, All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY,  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL DALLAS SEMICONDUCTOR BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Except as contained in this notice, the name of Dallas Semiconductor
+ * shall not be used except as stated in the Dallas Semiconductor
+ * Branding Policy.
+ *---------------------------------------------------------------------------
+ *
+ * shaibutton.c - Protocol-level functions as well as useful utility
+ *                functions for sha applications.
+ *
+ * Version: 2.10
+ */
+
+#include "ownet.h"
+#include "shaib.h"
+
+/* Global */
+SMALLINT in_overdrive[MAX_PORTNUM];
+
+/*---------------------------------------------------------------------
+ * Uses File I/O API to find the coprocessor with a specific
+ * coprocessor file name.  Usually 'COPR.0'.
+ *
+ * 'copr'   - Structure for holding coprocessor information
+ * 'fe'     - pointer to file entry structure, with proper filename.
+ *
+ * Returns: TRUE, found a valid coprocessor
+ *          FALSE, no coprocessor is present
+ */
+#if 0
+SMALLINT FindCoprSHA(SHACopr* copr, FileEntry* fe)
+{
+   SMALLINT FoundCopr = FALSE;
+   int data;
+
+   /* now get all the SHA iButton parts until we find
+    * one that has the right file on it.
+    */
+   if(FindNewSHA(copr->portnum, copr->devAN, TRUE))
+   {
+      do
+      {
+         short handle;
+
+         if(owOpenFile(copr->portnum, copr->devAN, fe, &handle))
+         {
+            int length = fe->NumPgs << 5;
+            uchar* raw = malloc(length*5);
+
+            if(owReadFile(copr->portnum, copr->devAN,
+                          handle, raw,
+                          length, &length))
+            {
+               if(!owCloseFile(copr->portnum, copr->devAN, handle))
+                  return FALSE;
+               if(raw != 0)
+                  data = GetCoprFromRawData(copr, raw, length);
+               FoundCopr = TRUE;
+            }
+
+            free(raw);
+         }
+      }
+      while(!FoundCopr && FindNewSHA(copr->portnum, copr->devAN, FALSE));
+   }
+
+   return FoundCopr;
+}
+#endif
+
+/*---------------------------------------------------------------------
+ * Extracts coprocessor configuration information from raw data.
+ * Returns the last unaccessed index.
+ *
+ * 'copr'   - Structure for holding coprocessor information
+ * 'raw'    - Raw bytes, usually from file stored on disk or on the
+ *            coprocessor itself.
+ * 'length' - The length of coprocessor data.
+ */
+int GetCoprFromRawData(SHACopr* copr, uchar* raw, int length)
+{
+   int i, namelen, siglen, auxlen;
+   /* copy in the name of the user's service file */
+   memcpy(copr->serviceFilename, raw, 5);
+
+   /* various page numbers */
+   copr->signPageNumber = raw[5];
+   copr->authPageNumber = raw[6];
+   copr->wspcPageNumber = raw[7];
+
+   /* version information */
+   copr->versionNumber = raw[8];
+
+   /* skip 4 bytes for date info;
+    * get bind data, bind code, and signing challenge
+    */
+   memcpy(copr->bindData, &raw[13], 32);
+   memcpy(copr->bindCode, &raw[45], 7);
+   memcpy(copr->signChlg, &raw[52], 3);
+
+   namelen = raw[55];
+   siglen = raw[56];
+   auxlen = raw[57];
+
+   /* read in provider name as null-terminated string */
+   copr->providerName = malloc(namelen+1);
+   memcpy(copr->providerName, &raw[58], namelen);
+   copr->providerName[namelen] = '\0';
+
+   /* get initial signature */
+   memcpy(copr->initSignature, &raw[58+namelen],
+            (siglen>20?20:siglen) );
+
+   /* read in auxilliary data as null-terminated string */
+   copr->auxilliaryData = malloc(auxlen+1);
+   memcpy(copr->auxilliaryData,
+            &raw[58+namelen+siglen], auxlen);
+   copr->auxilliaryData[auxlen] = '\0';
+
+   /* encryption code */
+   i = 58+namelen+siglen+auxlen;
+   copr->encCode = raw[i];
+
+   /* ds1961S compatibility flag - optional */
+   if((length>i+1) && (raw[i+1]!=0))
+      copr->ds1961Scompatible = TRUE;
+   else
+      copr->ds1961Scompatible = FALSE;
+
+   return i+2;
+}
+
+/*---------------------------------------------------------------------
+ * Uses File I/O API to find the user token with a specific
+ * service file name.  Usually 'DSLM.102'.
+ *
+ * 'user'       - Structure for holding user token information
+ * 'fe'         - pointer to file entry structure, with proper
+ *                service filename.
+ * 'doBlocking' - if TRUE, method blocks until a user token is found.
+ *
+ * Returns: TRUE, found a valid user token
+ *          FALSE, no user token is present
+ */
+#if 0
+SMALLINT FindUserSHA(SHAUser* user, FileEntry* fe,
+                     SMALLINT doBlocking)
+{
+   SMALLINT FoundUser = FALSE;
+
+   for(;;)
+   {
+      /* now get all the SHA iButton parts until we find
+       * one that has the right file on it.
+       */
+      while(!FoundUser && FindNewSHA(user->portnum, user->devAN, FALSE))
+      {
+         short handle;
+
+         if(owOpenFile(user->portnum, user->devAN, fe, &handle))
+         {
+            user->accountPageNumber = fe->Spage;
+            FoundUser = TRUE;
+            if(!owCloseFile(user->portnum, user->devAN, handle))
+               return FALSE;
+         }
+      }
+
+      if(FoundUser)
+         return TRUE;
+      else if(!doBlocking)
+         return FALSE;
+   }
+}
+#endif
+
+/* final buffer for tracking list of known SHA parts
+ * only holds the CRC for each part
+ */
+static uchar ListOfKnownSHA[MAX_PORTNUM][MAX_SHA_IBUTTONS];
+static int listIndex = 0;
+/* intermediate buffer for tracking list of known SHA parts */
+static uchar listBuffer[MAX_PORTNUM][MAX_SHA_IBUTTONS];
+static int indexBuffer = 0;
+/* holds last state of FindNewSHA */
+static SMALLINT needsFirst = FALSE;
+
+/*---------------------------------------------------------------------
+ * Finds new SHA iButtons on the given port.  Uses 'triple-buffer'
+ * technique to insure it only finds 'new' buttons.
+ *
+ * 'portnum'     - number 0 to MAX_PORTNUM-1.  This number is provided to
+ *                 indicate the symbolic port number.
+ * 'devAN'       - pointer to buffer for device address
+ * 'resetList'   - if TRUE, final buffer is cleared.
+ *
+ * Returns: TRUE, found a new SHA iButton.
+ *          FALSE, no new buttons are present.
+ */
+SMALLINT FindNewSHA(int portnum, uchar* devAN, SMALLINT resetList)
+{
+   uchar ROM[8];
+   uchar tempList[MAX_SHA_IBUTTONS] = {0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+                                       0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00};
+   int tempIndex = 0, i;
+   SMALLINT hasDevices = TRUE, completeList = FALSE;
+
+   /* force back to standard speed */
+   if(MODE_NORMAL != owSpeed(portnum,MODE_NORMAL))
+   {
+      OWERROR(OWERROR_LEVEL_FAILED);
+      return FALSE;
+   }
+
+   in_overdrive[portnum&0x0FF] = FALSE;
+
+   /* get first device in list with the specified family */
+   if(needsFirst || resetList)
+   {
+      hasDevices = owFirst(portnum, TRUE, FALSE);
+      completeList = TRUE;
+      if(resetList)
+         listIndex = 0;
+   }
+   else
+   {
+      hasDevices = owNext(portnum, TRUE, FALSE);
+   }
+
+   if(hasDevices)
+   {
+      do
+      {
+         /* verify correct device type */
+         owSerialNum(portnum, ROM, TRUE);
+         tempList[tempIndex++] = ROM[7];
+
+         /* compare crc to complete list of ROMs */
+         for(i=0; i<listIndex; i++)
+         {
+            if(ROM[7] == ListOfKnownSHA[portnum&0x0FF][i])
+               break;
+         }
+
+         /* found no match; */
+         if(i==listIndex)
+         {
+            /* check if correct type and not copr_rom */
+            if ((SHA_FAMILY_CODE   == (ROM[0] & 0x7F)) ||
+                (SHA33_FAMILY_CODE == (ROM[0] & 0x7F)))
+            {
+               /* save the ROM to the return buffer */
+               owSerialNum(portnum,devAN,TRUE);
+               ListOfKnownSHA[portnum&0x0FF][listIndex++] = devAN[7];
+               return TRUE;
+            }
+         }
+      }
+      while(owNext(portnum, TRUE, FALSE));
+   }
+
+   /* depleted the list, start over from beginning next time */
+   needsFirst = TRUE;
+
+   if(completeList)
+   {
+      /* known list is triple-buffered, listBuffer is intermediate
+       * buffer.  tempList is the immediate buffer, while
+       * ListOfKnownSHA is the final buffer.
+       */
+      if( (memcmp(tempList, listBuffer[portnum&0x0FF], MAX_SHA_IBUTTONS)==0) &&
+          tempIndex == indexBuffer )
+      {
+         memcpy(ListOfKnownSHA[portnum&0x0FF], tempList, MAX_SHA_IBUTTONS);
+         listIndex = tempIndex;
+      }
+      else
+      {
+         memcpy(listBuffer[portnum&0x0FF], tempList, MAX_SHA_IBUTTONS);
+         indexBuffer = tempIndex;
+      }
+
+   }
+   return FALSE;
+}
+
+
+/*-------------------------------------------------------------------------
+ * Select the current device and attempt overdrive if possible.  Usable
+ * for both DS1963S and DS1961S.
+ *
+ * 'portnum'     - number 0 to MAX_PORTNUM-1.  This number is provided to
+ *                 indicate the symbolic port number.
+ *
+ * Return: TRUE - device selected
+ *         FALSE - device not select
+ */
+SMALLINT SelectSHA(int portnum)
+{
+   int rt,cnt=0;
+
+#ifdef __MC68K__
+   /* Used in when overdrive isn't...Used owVerify for overdrive */
+   rt = owAccess(portnum);
+#else
+   #ifdef DEBUG_DUMP
+      uchar ROM[8];
+      int i, mcnt;
+      char msg[255];
+
+      owSerialNum(portnum,ROM, TRUE);
+      mcnt = sprintf(msg,"\n  Device select ");
+      for (i = 0; i < 8; i++)
+         mcnt += sprintf(msg + mcnt, "%02X",ROM[i]);
+      mcnt += sprintf(msg + mcnt,"\n");
+      printf("%s",msg);
+   #endif
+
+   /* loop to access the device and optionally do overdrive */
+   do
+   {
+      rt = owVerify(portnum,FALSE);
+
+      /* check not present */
+      if (rt != 1)
+      {
+         /* if in overdrive, drop back */
+         if (in_overdrive[portnum&0x0FF])
+         {
+            /* set to normal speed */
+            if(MODE_NORMAL == owSpeed(portnum,MODE_NORMAL))
+            	in_overdrive[portnum&0x0FF] = FALSE;
+         }
+      }
+      /* present but not in overdrive */
+      else if (!in_overdrive[portnum&0x0FF])
+      {
+         /* put all devices in overdrive */
+         if (owTouchReset(portnum))
+         {
+            if (owWriteByte(portnum,0x3C))
+            {
+               /* set to overdrive speed */
+               if(MODE_OVERDRIVE == owSpeed(portnum,MODE_OVERDRIVE))
+               		in_overdrive[portnum&0x0FF] = TRUE;
+            }
+         }
+
+         rt = 0;
+      }
+      else
+         break;
+   }
+   while ((rt != 1) && (cnt++ < 3));
+#endif
+
+   return rt;
+}
+
+
+/*-------------------------------------------------------------------------
+ * Creates a random challenge using the SHA engine of the given
+ * coprocessor.
+ *
+ * 'copr'      - Structure for holding coprocessor information.
+ * 'pagenum'   - pagenumber to use for calculation.
+ * 'chlg'      - 3-byte return buffer for challenge.
+ * 'offset'    - offset into resulting MAC to pull challenge data from.
+ *
+ * Return: TRUE - create challenge succeeded.
+ *         FALSE - an error occurred.
+ */
+SMALLINT CreateChallenge(SHACopr* copr, SMALLINT pageNum,
+                         uchar* chlg, SMALLINT offset)
+{
+   uchar scratchpad[32];
+   int   addr = pageNum << 5;
+   uchar es = 0x1F;
+   int   start = 8;
+
+   if(offset>0 && offset<17)
+      start += offset;
+
+   /* set the serial number */
+   owSerialNum(copr->portnum, copr->devAN, FALSE);
+
+   OWASSERT( EraseScratchpadSHA18(copr->portnum, addr, FALSE),
+             OWERROR_ERASE_SCRATCHPAD_FAILED, FALSE );
+
+   OWASSERT( SHAFunction18(copr->portnum, SHA_COMPUTE_CHALLENGE, addr, TRUE),
+             OWERROR_SHA_FUNCTION_FAILED, FALSE );
+
+   OWASSERT( ReadScratchpadSHA18(copr->portnum, &addr, &es, scratchpad, TRUE),
+             OWERROR_READ_SCRATCHPAD_FAILED, FALSE );
+
+   memcpy(chlg,&scratchpad[start],3);
+
+   return TRUE;
+}
+
+/*-------------------------------------------------------------------------
+ * Answers a random challenge by performing an authenticated read of the
+ * user's account information.
+ *
+ * 'user'      - Structure for holding user token information.
+ * 'chlg'      - 3-byte buffer of challenge data.
+ *
+ * Return: the value of the write cycle counter for the account page.
+ *         or -1 if there is an error
+ */
+#if 0
+int AnswerChallenge(SHAUser* user, uchar* chlg)
+{
+   int addr = user->accountPageNumber << 5;
+
+   user->writeCycleCounter = -1;
+   memcpy(&user->accountFile[20], chlg, 3);
+
+   /* set the serial number */
+   owSerialNum(user->portnum, user->devAN, FALSE);
+
+   if(user->devAN[0]==0x18)
+   {
+      /* for the DS1963S */
+      OWASSERT( EraseScratchpadSHA18(user->portnum, addr, FALSE),
+                OWERROR_ERASE_SCRATCHPAD_FAILED, -1 );
+
+      OWASSERT( WriteScratchpadSHA18(user->portnum, addr,
+                                     user->accountFile, 32,
+                                     TRUE),
+                 OWERROR_WRITE_SCRATCHPAD_FAILED, -1 );
+
+      user->writeCycleCounter =
+         ReadAuthPageSHA18(user->portnum,
+                           user->accountPageNumber,
+                           user->accountFile,
+                           user->responseMAC, TRUE);
+   }
+   else if(user->devAN[0]==0x33||user->devAN[0]==0xB3)
+   {
+      /* for the DS1961S */
+      OWASSERT( WriteScratchpadSHA33(user->portnum, addr,
+                                     &user->accountFile[16],
+                                     FALSE),
+                 OWERROR_WRITE_SCRATCHPAD_FAILED, -1 );
+
+      user->writeCycleCounter =
+         ReadAuthPageSHA33(user->portnum,
+                           user->accountPageNumber,
+                           user->accountFile,
+                           user->responseMAC, TRUE);
+   }
+   return user->writeCycleCounter;
+}
+#endif
+
+/*-------------------------------------------------------------------------
+ * Verifies the authentication response of a user token.
+ *
+ * 'copr'      - Structure for holding coprocessor information.
+ * 'user'      - Structure for holding user token information.
+ * 'chlg'      - 3-byte buffer of challenge data.
+ * 'doBind'    - if true, the user's unique secret is recreated on the
+ *               coprocessor.  If this function is called multiple times,
+ *               it is acceptable to skip the bind for all calls after
+ *               the first on the same user token.
+ *
+ * Return: If TRUE, the user's authentication response matched exactly the
+ *            signature generated by the coprocessor.
+ *         If FALSE, an error occurred or the signature did not match.
+ */
+SMALLINT VerifyAuthResponse(SHACopr* copr, SHAUser* user,
+                            uchar* chlg, SMALLINT doBind)
+{
+   int addr = copr->wspcPageNumber << 5;
+   int wcc = user->writeCycleCounter;
+   uchar sign_cmd;
+   uchar scratchpad[32];
+   uchar fullBindCode[15];
+
+   memset(scratchpad, 0x00, 32);
+   memset(fullBindCode, 0x0FF, 15);
+
+   /* format the bind code properly */
+   if(user->devAN[0]==0x18)
+   {
+      /* Format for DS1963S */
+      memcpy(fullBindCode, copr->bindCode, 4);
+      memcpy(&fullBindCode[12], &(copr->bindCode[4]), 3);
+      /* use ValidateDataPage command */
+      sign_cmd = SHA_VALIDATE_DATA_PAGE;
+      /* copy wcc LSB first */
+      if(!IntToBytes(&scratchpad[8], 4, wcc))
+         OWERROR(OWERROR_NO_ERROR_SET);
+   }
+   else if(user->devAN[0]==0x33||user->devAN[0]==0xB3)
+   {
+      /* Leave bindCode FF for DS1961S */
+      /* Use AuthenticateHost command */
+      sign_cmd = SHA_AUTHENTICATE_HOST;
+      /* the user doesn't have a write cycle counter */
+      memset(&scratchpad[8], 0x0FF, 4);
+   }
+   else
+   {
+      OWERROR(OWERROR_WRONG_TYPE);
+      return FALSE;
+   }
+
+   /* the pagenumber */
+   fullBindCode[4] = (uchar)user->accountPageNumber;
+   /* and 7 bytes of the address of current device */
+   memcpy(&fullBindCode[5], user->devAN, 7);
+
+   /* get the user address and page num from fullBindCode */
+   memcpy(&scratchpad[12], &fullBindCode[4], 8);
+   /* set the same challenge bytes */
+   memcpy(&scratchpad[20], chlg, 3);
+
+   /* set the serial number to that of the coprocessor */
+   owSerialNum(copr->portnum, copr->devAN, FALSE);
+
+   /* install user's unique secret on the wspc secret */
+   if(doBind)
+   {
+      OWASSERT( BindSecretToiButton18(copr->portnum,
+                                      copr->authPageNumber,
+                                      copr->wspcPageNumber&7,
+                                      copr->bindData, fullBindCode, FALSE),
+                OWERROR_BIND_SECRET_FAILED, FALSE );
+      if(user->devAN[0]==0x33||user->devAN[0]==0xB3)
+      {
+         /* also copy the resulting secret into secret location 0, to
+          * replace the signing secret.  Necessary for producing the
+          * DS1961S's write-authorization MAC.
+          */
+         OWASSERT( CopySecretSHA18(copr->portnum, 0),
+                   OWERROR_COPY_SECRET_FAILED, FALSE);
+      }
+   }
+
+   /* recreate the signature and verify */
+   OWASSERT( WriteDataPageSHA18(copr->portnum, copr->wspcPageNumber,
+                              user->accountFile, doBind),
+              OWERROR_WRITE_DATA_PAGE_FAILED, FALSE );
+
+   OWASSERT( WriteScratchpadSHA18(copr->portnum, addr, scratchpad, 32, TRUE),
+              OWERROR_WRITE_SCRATCHPAD_FAILED, FALSE );
+
+   OWASSERT( SHAFunction18(copr->portnum, sign_cmd, addr, TRUE),
+             OWERROR_SHA_FUNCTION_FAILED, FALSE );
+
+   OWASSERT( MatchScratchpadSHA18(copr->portnum,
+                                user->responseMAC, TRUE),
+             OWERROR_MATCH_SCRATCHPAD_FAILED, FALSE );
+
+   return TRUE;
+}
+
+/*-------------------------------------------------------------------------
+ * Creates a data signature for the given data buffer using the hardware
+ * coprocessor.
+ *
+ * 'copr'          - Structure for holding coprocessor information.
+ * 'data'          - data written to the data page to sign
+ * 'scratchpad'    - data written to the scratchpad to sign
+ * 'signature'     - data buffer which is either holding the signature that
+ *                   must match exactly what is generated on the coprocessor
+ *                   -or- will hold the resulting signature created by the
+ *                   coprocessor.
+ * 'readSignature' - implies whether or not the signature buffer
+ *                   receives the contents of the scratchpad or is used to
+ *                   match the contents of the scratchpad.  If true,
+ *                   scratchpad contents are read into the signature buffer.
+ *
+ * Return: If TRUE, the user's authentication response matched exactly the
+ *            signature generated by the coprocessor or the signature was
+ *            successfully copied into the return buffer.
+ *         If FALSE, an error occurred or the signature did not match.
+ */
+SMALLINT CreateDataSignature(SHACopr* copr, uchar* data,
+                             uchar* scratchpad, uchar* signature,
+                             SMALLINT readSignature)
+{
+   int addr = copr->signPageNumber << 5;
+
+   /* set the serial number to that of the coprocessor */
+   owSerialNum(copr->portnum, copr->devAN, FALSE);
+
+   OWASSERT( WriteDataPageSHA18(copr->portnum, copr->signPageNumber,
+                              data, FALSE),
+              OWERROR_WRITE_DATA_PAGE_FAILED, FALSE );
+
+   OWASSERT( WriteScratchpadSHA18(copr->portnum, addr,
+                                scratchpad, 32, TRUE),
+              OWERROR_WRITE_SCRATCHPAD_FAILED, FALSE );
+
+   OWASSERT( SHAFunction18(copr->portnum, SHA_SIGN_DATA_PAGE,
+                         addr, TRUE),
+             OWERROR_SHA_FUNCTION_FAILED, FALSE );
+
+   if(readSignature)
+   {
+      OWASSERT( ReadScratchpadSHA18(copr->portnum, 0, 0,
+                                  scratchpad, TRUE),
+                 OWERROR_READ_SCRATCHPAD_FAILED, FALSE );
+   }
+   else
+   {
+      OWASSERT( MatchScratchpadSHA18(copr->portnum,
+                                   signature, TRUE),
+                 OWERROR_MATCH_SCRATCHPAD_FAILED, FALSE );
+   }
+
+   memcpy(signature, &scratchpad[8], 20);
+
+   return TRUE;
+}
+
+
+/*-------------------------------------------------------------------------
+ * Decipher the variable Val into a 'len' byte array to set
+ * LSB First
+ */
+SMALLINT IntToBytes(uchar* byteArray, int len, unsigned int val)
+{
+   int i = 0;
+   for (; i<len; i++)
+   {
+      byteArray[i] = (uchar)val;
+      val >>= 8;
+   }
+
+   if(val==0)
+      return TRUE;
+   else
+      return FALSE;
+}
+
+/*-------------------------------------------------------------------------
+ * Decipher the range 'len' of the byte array to an integer
+ * LSB First
+ */
+int BytesToInt(uchar* byteArray, int len)
+{
+   unsigned int val = 0;
+   int i = (len - 1);
+   /* Concatanate the byte array into one variable. */
+   for (; i >= 0; i--)
+   {
+      val <<= 8;
+      val |= (byteArray[i] & 0x00FF);
+   }
+   return val;
+}

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ibutton/shaib.h
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/ibutton/shaib.h
@@ -1,0 +1,250 @@
+/* shaib.h */
+
+#ifndef SHAIBUTTON_H
+#define SHAIBUTTON_H
+
+/* for ANSI memory commands - memcpy,memcmp,memset */
+#include <string.h>
+#include <time.h>
+#include "ownet.h"
+#include "owfile.h"
+
+/*************************************************************************
+ * DS1963S SHA iButton commands
+ *************************************************************************/
+#define SHA_COMPUTE_FIRST_SECRET 0x0F
+#define SHA_COMPUTE_NEXT_SECRET  0xF0
+#define SHA_VALIDATE_DATA_PAGE   0x3C
+#define SHA_SIGN_DATA_PAGE       0xC3
+#define SHA_COMPUTE_CHALLENGE    0xCC
+#define SHA_AUTHENTICATE_HOST    0xAA
+#define CMD_READ_MEMORY          0xF0
+#define CMD_MATCH_SCRATCHPAD     0x3C
+#define CMD_WRITE_SCRATCHPAD     0x0F
+#define CMD_READ_SCRATCHPAD      0xAA
+#define CMD_ERASE_SCRATCHPAD     0xC3
+#define CMD_COPY_SCRATCHPAD      0x55
+#define CMD_READ_AUTH_PAGE       0xA5
+#define CMD_COMPUTE_SHA          0x33
+#define ROM_CMD_SKIP             0x3C
+#define ROM_CMD_RESUME           0xA5
+
+/*************************************************************************
+ * DS1961S SHA iButton commands - rest are shared with above
+ *************************************************************************/
+#define SHA33_LOAD_FIRST_SECRET     0x5A
+#define SHA33_COMPUTE_NEXT_SECRET   0x33
+#define SHA33_REFRESH_SCRATCHPAD    0xA3
+
+/*************************************************************************
+ * other constants
+ *************************************************************************/
+#define SHA_FAMILY_CODE        0x18
+#define SHA33_FAMILY_CODE      0x33
+/* maximum number of buttons to track on the port */
+#define MAX_SHA_IBUTTONS       16
+
+#define SHACoprFilename       "shacopr.cnf"
+
+/*************************************************************************
+ * SHA Device Structures
+ *************************************************************************/
+
+/* struct SHACopr
+ *   Holds all information pertinent to SHA coprocessors, as
+ *   well as all of the system parameters for this account
+ *   transaction system.
+ */
+typedef struct
+{
+   /* portnum and address of the device */
+   int   portnum;
+   uchar devAN[8];
+
+   /* name of the account file stored on the user token */
+   uchar serviceFilename[5];
+   /* memory page used for signing certificate data (0 or 8) */
+   uchar signPageNumber;
+   /* memory page used for storing master authentication secret
+    * and recreating user's unique secret
+    */
+   uchar authPageNumber;
+   /* memory page used for storing user's unique secret
+    * and verifying the user's authentication response
+    */
+   uchar wspcPageNumber;
+   /* version number of the system */
+   uchar versionNumber;
+   /* Binding information for producing unique secrets */
+   uchar bindCode[7];
+   uchar bindData[32];
+   /* challenge and signature used when signing account data */
+   uchar signChlg[3];
+   uchar initSignature[20];
+   /* name of the transaction system provider */
+   uchar* providerName; /* variable length */
+   /* any other pertinent information */
+   uchar* auxilliaryData; /* variable length */
+   /* encryption code, used to specify additional encryption */
+   uchar encCode;
+   /* indicates that the master authentication secret was
+    * padded to match the secret of a DS1961S
+    */
+   uchar ds1961Scompatible;
+
+} SHACopr;
+
+/* struct SHAUser
+ *   Holds all information pertinent to SHA user tokens.
+ *   Maintains state between routines for verifying the
+ *   user's authentication response, the account signature,
+ *   and updating the account data.
+ */
+typedef struct
+{
+   /* portnum and address of the device */
+   int   portnum;
+   uchar devAN[8];
+
+   /* page the user's account file is stored on */
+   uchar accountPageNumber;
+   /* Write cycle counter for account page */
+   int   writeCycleCounter;
+   /* MAC from Read Authenticated Page command */
+   uchar responseMAC[20];
+
+   /* 32-byte account file */
+   uchar accountFile[32];
+
+} SHAUser;
+
+/* struct DebitFile
+ *   Holds user token account data.  Byte-ordering
+ *   matters, so that this is a valid certificate
+ *   as specified by Application Note 151.
+ */
+typedef struct
+{
+   uchar fileLength;
+   uchar dataTypeCode;
+   uchar signature[20];
+   uchar convFactor[2];
+   uchar balanceBytes[3];
+   uchar transID[2];
+   uchar contPtr;
+   uchar crc16[2];
+
+} DebitFile;
+
+/* struct DebitFile33
+ *   Holds user token account data for DS1961S.
+ *   Usese Double octa-byte scheme for dual money
+ *   bytes and a pointer to the valid record.
+ */
+typedef struct
+{
+   /* header */
+   uchar fileLength;
+   uchar dataTypeCode;
+   uchar convFactor[2];
+   /* dont cares */
+   uchar dontCareBytes1[4];
+   /* record A */
+   uchar balanceBytes_A[3];
+   uchar transID_A[2];
+   uchar contPtr_A;
+   uchar crc16_A[2];
+   /* record B */
+   uchar balanceBytes_B[3];
+   uchar transID_B[2];
+   uchar contPtr_B;
+   uchar crc16_B[2];
+   /* dont cares */
+   uchar dontCareBytes2[8];
+
+} DebitFile33;
+
+/* file length used to point at Record A */
+#define RECORD_A_LENGTH 13
+/* file length used to point at Record B */
+#define RECORD_B_LENGTH 21
+
+
+/*************************************************************************
+ * DS1963S Low-level Functions - defined in sha18.c
+ *************************************************************************/
+
+/* General I/O */
+extern SMALLINT CopySecretSHA18(int portnum, SMALLINT secretnum);
+extern SMALLINT ReadScratchpadSHA18(int portnum, int* address,
+                                    uchar* es, uchar* data,
+                                    SMALLINT resume);
+extern SMALLINT WriteScratchpadSHA18(int portnum, int address,
+                                     const uchar *data, SMALLINT data_len,
+                                     SMALLINT resume);
+extern SMALLINT CopyScratchpadSHA18(int portnum, int address,
+                                    SMALLINT len, SMALLINT resume);
+extern SMALLINT MatchScratchpadSHA18(int portnum, uchar* data,
+                                     SMALLINT resume);
+extern SMALLINT EraseScratchpadSHA18(int portnum, int address,
+                                     SMALLINT resume);
+extern int ReadAuthPageSHA18(int portnum, SMALLINT pagenum, uchar* data,
+                             uchar* sign, SMALLINT resume);
+extern SMALLINT ReadMemoryPageSHA18(int portnum, SMALLINT pagenum, uchar* data,
+                                    SMALLINT resume);
+extern SMALLINT WriteDataPageSHA18(int portnum, SMALLINT pagenum,
+                                   uchar* data, SMALLINT resume);
+extern SMALLINT SHAFunction18(int portnum, uchar control_byte,
+                              int address, SMALLINT resume);
+/* Secret Installation */
+extern SMALLINT InstallSystemSecret18(int portnum, SMALLINT pagenum,
+                                      SMALLINT secretnum, uchar* secret,
+                                      int secret_length, SMALLINT resume);
+extern SMALLINT BindSecretToiButton18(int portnum, SMALLINT pagenum,
+                                      SMALLINT secretnum,
+                                      uchar* bindData, uchar* bindCode,
+                                      SMALLINT resume);
+/************************************************************************/
+
+
+/* General Util */
+extern void ReformatSecretFor1961S(uchar* auth_secret, int secret_length);
+extern void ComputeSHAVM(uchar* MT, long* hash);
+extern void HashToMAC(long* hash, uchar* MAC);
+/************************************************************************/
+
+/*************************************************************************
+ * Protocol-Level Functions - defined in shaibutton.c
+ *************************************************************************/
+
+/* Finding and accessing SHA iButtons */
+extern SMALLINT SelectSHA(int portnum);
+extern SMALLINT FindNewSHA(int portnum, uchar* devAN, SMALLINT forceFirst);
+/* extern SMALLINT FindUserSHA(SHAUser* user, FileEntry* fe, SMALLINT doBlocking); */
+/* extern SMALLINT FindCoprSHA(SHACopr* copr, FileEntry* fe); */
+extern int GetCoprFromRawData(SHACopr* copr, uchar* raw, int len);
+/* General Protocol functions for 1963S */
+extern SMALLINT CreateChallenge(SHACopr* copr, SMALLINT pageNum,
+                                uchar* chlg, SMALLINT offset);
+/* extern int AnswerChallenge(SHAUser* user, uchar* chlg); */
+extern SMALLINT VerifyAuthResponse(SHACopr* copr, SHAUser* user,
+                                   uchar* chlg, SMALLINT doBind);
+extern SMALLINT CreateDataSignature(SHACopr* copr, uchar* data,
+                                    uchar* scratchpad, uchar* signature,
+                                    SMALLINT readSignature);
+/* Useful utility functions */
+extern SMALLINT IntToBytes(uchar* byteArray, int len, unsigned int val);
+extern int BytesToInt(uchar* byteArray, int len);
+/************************************************************************/
+
+/************************************************************************/
+
+/* Global - defined in shaibutton.c */
+extern SMALLINT in_overdrive[MAX_PORTNUM];
+/************************************************************************/
+
+extern void PrintHexLabeled(char* label,uchar* buffer, int cnt);
+
+extern void ReadChars(uchar* buffer, int len);
+
+#endif /* SHAIBUTTON_H */

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/list.h
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/list.h
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2002, 2003 Lennert Buytenhek
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+/*
+ * This file contains a doubly linked list implementation API-compatible
+ * with the one found in the Linux kernel (in include/linux/list.h).
+ */
+
+#ifndef LIBPTRACE_LIST_H
+#define LIBPTRACE_LIST_H
+
+#include <stdio.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct list_head {
+	struct list_head	*next;
+	struct list_head	*prev;
+};
+
+#define LIST_HEAD_INIT(name) { &(name), &(name) }
+
+static inline void list_init(struct list_head *lh)
+{
+	lh->next = lh;
+	lh->prev = lh;
+}
+
+static inline void list_add(struct list_head *lh, struct list_head *head)
+{
+	lh->next = head->next;
+	lh->prev = head;
+	head->next->prev = lh;
+	head->next = lh;
+}
+
+static inline void list_add_tail(struct list_head *lh, struct list_head *head)
+{
+	lh->next = head;
+	lh->prev = head->prev;
+	head->prev->next = lh;
+	head->prev = lh;
+}
+
+static inline void list_del(struct list_head *lh)
+{
+	lh->prev->next = lh->next;
+	lh->next->prev = lh->prev;
+	lh->prev = NULL;
+	lh->next = NULL;
+}
+
+static inline void list_del_init(struct list_head *lh)
+{
+	lh->prev->next = lh->next;
+	lh->next->prev = lh->prev;
+	list_init(lh);
+}
+
+static inline int list_empty(struct list_head *head)
+{
+	return head->next == head;
+}
+
+#define list_entry(lh, type, member) \
+	((type *)((char *)(lh) - (uintptr_t)(&((type *)0)->member)))
+
+#define list_for_each(lh, head) \
+	for (lh = (head)->next; lh != (head); lh = lh->next)
+
+#define list_for_each_safe(lh, lh2, head) \
+	for (lh = (head)->next, lh2 = lh->next; lh != (head); \
+		lh = lh2, lh2 = lh->next)
+
+#define list_for_each_prev(lh, head) \
+        for (lh = (head)->prev; lh != (head); lh = lh->prev)
+
+#ifdef __cplusplus
+};
+#endif
+
+#endif

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/sha1.c
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/sha1.c
@@ -1,0 +1,188 @@
+/*
+ * ftp://ftp.funet.fi/pub/crypt/hash/sha/sha1.c
+ * 
+ * SHA-1 in C
+ * By Steve Reid <steve@edmweb.com>
+ * 100% Public Domain
+ * 
+ * Test Vectors (from FIPS PUB 180-1)
+ * "abc"
+ * A9993E36 4706816A BA3E2571 7850C26C 9CD0D89D
+ * "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"
+ * 84983E44 1C3BD26E BAAE4AA1 F95129E5 E54670F1
+ * A million repetitions of "a"
+ * 34AA973C D4C4DAA4 F61EEB2B DBAD2731 6534016F
+ */
+
+/* #define SHA1HANDSOFF * Copies data before messing with it. */
+
+#include <string.h>
+#include <netinet/in.h>	/* htonl() */
+#include <net/ppp_defs.h>
+#include "sha1.h"
+
+static void
+SHA1_Transform(u_int32_t[5], const unsigned char[64]);
+
+#define rol(value, bits) (((value) << (bits)) | ((value) >> (32 - (bits))))
+
+/* blk0() and blk() perform the initial expand. */
+/* I got the idea of expanding during the round function from SSLeay */
+#define blk0(i) (block->l[i] = htonl(block->l[i]))
+#define blk(i) (block->l[i&15] = rol(block->l[(i+13)&15]^block->l[(i+8)&15] \
+    ^block->l[(i+2)&15]^block->l[i&15],1))
+
+/* (R0+R1), R2, R3, R4 are the different operations used in SHA1 */
+#define R0(v,w,x,y,z,i) z+=((w&(x^y))^y)+blk0(i)+0x5A827999+rol(v,5);w=rol(w,30);
+#define R1(v,w,x,y,z,i) z+=((w&(x^y))^y)+blk(i)+0x5A827999+rol(v,5);w=rol(w,30);
+#define R2(v,w,x,y,z,i) z+=(w^x^y)+blk(i)+0x6ED9EBA1+rol(v,5);w=rol(w,30);
+#define R3(v,w,x,y,z,i) z+=(((w|x)&y)|(w&x))+blk(i)+0x8F1BBCDC+rol(v,5);w=rol(w,30);
+#define R4(v,w,x,y,z,i) z+=(w^x^y)+blk(i)+0xCA62C1D6+rol(v,5);w=rol(w,30);
+
+
+/* Hash a single 512-bit block. This is the core of the algorithm. */
+
+static void
+SHA1_Transform(u_int32_t state[5], const unsigned char buffer[64])
+{
+    u_int32_t a, b, c, d, e;
+    typedef union {
+	unsigned char c[64];
+	u_int32_t l[16];
+    } CHAR64LONG16;
+    CHAR64LONG16 *block;
+
+#ifdef SHA1HANDSOFF
+    static unsigned char workspace[64];
+    block = (CHAR64LONG16 *) workspace;
+    memcpy(block, buffer, 64);
+#else
+    block = (CHAR64LONG16 *) buffer;
+#endif
+    /* Copy context->state[] to working vars */
+    a = state[0];
+    b = state[1];
+    c = state[2];
+    d = state[3];
+    e = state[4];
+    /* 4 rounds of 20 operations each. Loop unrolled. */
+    R0(a,b,c,d,e, 0); R0(e,a,b,c,d, 1); R0(d,e,a,b,c, 2); R0(c,d,e,a,b, 3);
+    R0(b,c,d,e,a, 4); R0(a,b,c,d,e, 5); R0(e,a,b,c,d, 6); R0(d,e,a,b,c, 7);
+    R0(c,d,e,a,b, 8); R0(b,c,d,e,a, 9); R0(a,b,c,d,e,10); R0(e,a,b,c,d,11);
+    R0(d,e,a,b,c,12); R0(c,d,e,a,b,13); R0(b,c,d,e,a,14); R0(a,b,c,d,e,15);
+    R1(e,a,b,c,d,16); R1(d,e,a,b,c,17); R1(c,d,e,a,b,18); R1(b,c,d,e,a,19);
+    R2(a,b,c,d,e,20); R2(e,a,b,c,d,21); R2(d,e,a,b,c,22); R2(c,d,e,a,b,23);
+    R2(b,c,d,e,a,24); R2(a,b,c,d,e,25); R2(e,a,b,c,d,26); R2(d,e,a,b,c,27);
+    R2(c,d,e,a,b,28); R2(b,c,d,e,a,29); R2(a,b,c,d,e,30); R2(e,a,b,c,d,31);
+    R2(d,e,a,b,c,32); R2(c,d,e,a,b,33); R2(b,c,d,e,a,34); R2(a,b,c,d,e,35);
+    R2(e,a,b,c,d,36); R2(d,e,a,b,c,37); R2(c,d,e,a,b,38); R2(b,c,d,e,a,39);
+    R3(a,b,c,d,e,40); R3(e,a,b,c,d,41); R3(d,e,a,b,c,42); R3(c,d,e,a,b,43);
+    R3(b,c,d,e,a,44); R3(a,b,c,d,e,45); R3(e,a,b,c,d,46); R3(d,e,a,b,c,47);
+    R3(c,d,e,a,b,48); R3(b,c,d,e,a,49); R3(a,b,c,d,e,50); R3(e,a,b,c,d,51);
+    R3(d,e,a,b,c,52); R3(c,d,e,a,b,53); R3(b,c,d,e,a,54); R3(a,b,c,d,e,55);
+    R3(e,a,b,c,d,56); R3(d,e,a,b,c,57); R3(c,d,e,a,b,58); R3(b,c,d,e,a,59);
+    R4(a,b,c,d,e,60); R4(e,a,b,c,d,61); R4(d,e,a,b,c,62); R4(c,d,e,a,b,63);
+    R4(b,c,d,e,a,64); R4(a,b,c,d,e,65); R4(e,a,b,c,d,66); R4(d,e,a,b,c,67);
+    R4(c,d,e,a,b,68); R4(b,c,d,e,a,69); R4(a,b,c,d,e,70); R4(e,a,b,c,d,71);
+    R4(d,e,a,b,c,72); R4(c,d,e,a,b,73); R4(b,c,d,e,a,74); R4(a,b,c,d,e,75);
+    R4(e,a,b,c,d,76); R4(d,e,a,b,c,77); R4(c,d,e,a,b,78); R4(b,c,d,e,a,79);
+
+    /* Add the working vars back into context.state[] */
+    state[0] += a;
+    state[1] += b;
+    state[2] += c;
+    state[3] += d;
+    state[4] += e;
+    /* Wipe variables */
+    a = b = c = d = e = 0;
+}
+
+
+/* SHA1Init - Initialize new context */
+
+void
+SHA1_Init(SHA1_CTX *context)
+{
+    /* SHA1 initialization constants */
+    context->state[0] = 0x67452301;
+    context->state[1] = 0xEFCDAB89;
+    context->state[2] = 0x98BADCFE;
+    context->state[3] = 0x10325476;
+    context->state[4] = 0xC3D2E1F0;
+    context->count[0] = context->count[1] = 0;
+}
+
+
+/* Run your data through this. */
+
+void
+SHA1_Update(SHA1_CTX *context, const unsigned char *data, unsigned int len)
+{
+    unsigned int i, j;
+
+    j = (context->count[0] >> 3) & 63;
+    if ((context->count[0] += len << 3) < (len << 3)) context->count[1]++;
+    context->count[1] += (len >> 29);
+    i = 64 - j;
+    while (len >= i) {
+	memcpy(&context->buffer[j], data, i);
+	SHA1_Transform(context->state, context->buffer);
+	data += i;
+	len -= i;
+	i = 64;
+	j = 0;
+    }
+
+    memcpy(&context->buffer[j], data, len);
+}
+
+
+/* Add padding and return the message digest. */
+
+void
+SHA1_Final(unsigned char digest[20], SHA1_CTX *context)
+{
+    u_int32_t i, j;
+    unsigned char finalcount[8];
+
+    for (i = 0; i < 8; i++) {
+        finalcount[i] = (unsigned char)((context->count[(i >= 4 ? 0 : 1)]
+         >> ((3-(i & 3)) * 8) ) & 255);  /* Endian independent */
+    }
+    SHA1_Update(context, (unsigned char *) "\200", 1);
+    while ((context->count[0] & 504) != 448) {
+	SHA1_Update(context, (unsigned char *) "\0", 1);
+    }
+    SHA1_Update(context, finalcount, 8);  /* Should cause a SHA1Transform() */
+    for (i = 0; i < 20; i++) {
+	digest[i] = (unsigned char)
+		     ((context->state[i>>2] >> ((3-(i & 3)) * 8) ) & 255);
+    }
+    /* Wipe variables */
+    i = j = 0;
+    memset(context->buffer, 0, 64);
+    memset(context->state, 0, 20);
+    memset(context->count, 0, 8);
+    memset(&finalcount, 0, 8);
+#ifdef SHA1HANDSOFF  /* make SHA1Transform overwrite it's own static vars */
+    SHA1Transform(context->state, context->buffer);
+#endif
+}
+
+#if 0
+int main(void)
+{
+	char buf[64];
+	SHA1_CTX ctx;
+	int i;
+
+	for (i = 0; i < 0xFFFFFFFF; i++) {
+		SHA1_Init(&ctx);
+		SHA1_Update(&ctx, buf, 64);
+
+		if (i % 0x10000 == 0)
+			printf("%.8x\n", i);
+	}
+}
+
+#endif

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/sha1.h
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/sha1.h
@@ -1,0 +1,18 @@
+#ifndef SHA1_INCLUDE
+#define SHA1_INCLUDE
+
+#include <stdint.h>
+
+#define SHA1_SIGNATURE_SIZE 20
+
+typedef struct {
+    uint32_t state[5];
+    uint32_t count[2];
+    unsigned char buffer[64];
+} SHA1_CTX;
+
+extern void SHA1_Init(SHA1_CTX *);
+extern void SHA1_Update(SHA1_CTX *, const unsigned char *, unsigned int);
+extern void SHA1_Final(unsigned char[SHA1_SIGNATURE_SIZE], SHA1_CTX *);
+
+#endif /* SHA1_INCLUDE_ */

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/transport-factory.c
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/transport-factory.c
@@ -1,0 +1,57 @@
+/* transport-factory.c
+ *
+ * A factory for transport layer instances.
+ *
+ * Dedicated to Yuzuyu Arielle Huizer.
+ *
+ * Copyright (C) 2016-2019  Ronald Huizer <rhuizer@hexpedition.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include <string.h>
+#include "transport-factory.h"
+#include "transport-pty.h"
+#include "transport-unix.h"
+
+struct transport *
+transport_factory_new(int type)
+{
+	struct transport *t = NULL;
+
+	switch (type) {
+	case TRANSPORT_PTY:
+		t = transport_pty_new();
+		break;
+	case TRANSPORT_UNIX:
+		t = transport_unix_new();
+		break;
+	}
+
+	if (t != NULL)
+		t->type = type;
+
+	return t;
+}
+
+struct transport *
+transport_factory_new_by_name(const char *name)
+{
+	if (!strcmp(name, "pty"))
+		return transport_factory_new(TRANSPORT_PTY);
+
+	if (!strcmp(name, "unix"))
+		return transport_factory_new(TRANSPORT_UNIX);
+
+	return NULL;
+}

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/transport-factory.h
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/transport-factory.h
@@ -1,0 +1,41 @@
+/* transport-factory.c
+ *
+ * A factory for transport layer instances.
+ *
+ * Dedicated to Yuzuyu Arielle Huizer.
+ *
+ * Copyright (C) 2016-2019  Ronald Huizer <rhuizer@hexpedition.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef TRANSPORT_FACTORY_H
+#define TRANSPORT_FACTORY_H
+
+#include "transport.h"
+
+#define TRANSPORT_UNIX	1
+#define TRANSPORT_PTY	2
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct transport *transport_factory_new(int type);
+struct transport *transport_factory_new_by_name(const char *name);
+
+#ifdef __cplusplus
+};
+#endif
+
+#endif

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/transport-pty.c
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/transport-pty.c
@@ -1,0 +1,168 @@
+/* transport-pty.c
+ *
+ * Transport layer pty implementation.
+ *
+ * Dedicated to Yuzuyu Arielle Huizer.
+ *
+ * Copyright (C) 2019  Ronald Huizer <rhuizer@hexpedition.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#define _XOPEN_SOURCE 600
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include "transport-pty.h"
+
+static struct transport_operations transport_pty_operations;
+
+static int
+close_no_EINTR(int fd)
+{
+	int ret;
+
+	do {
+		ret = close(fd);
+	} while (ret == -1 && errno == EINTR);
+
+	return ret;
+}
+
+static ssize_t
+read_no_EINTR(int fd, void *buf, size_t count)
+{
+	ssize_t ret;
+
+	do {
+		ret = read(fd, buf, count);
+	} while (ret == -1 && errno == EINTR);
+
+	return ret;
+}
+
+static ssize_t
+write_no_EINTR(int fd, const void *buf, size_t count)
+{
+	ssize_t ret;
+
+	do {
+		ret = write(fd, buf, count);
+	} while (ret == -1 && errno == EINTR);
+
+	return ret;
+}
+
+int
+transport_pty_init(struct transport *t)
+{
+	struct transport_pty_data *data;
+
+	assert(t != NULL);
+
+	if ( (data = malloc(sizeof *data)) == NULL)
+		goto err;
+
+	if ( (data->fd = posix_openpt(O_RDWR | O_NOCTTY)) == -1)
+		goto err_free;
+
+	if (grantpt(data->fd) == -1)
+		goto err_fd;
+
+	if (unlockpt(data->fd) == -1)
+		goto err_fd;
+
+	if ( (data->pathname_slave = ptsname(data->fd)) == NULL)
+		goto err_fd;
+
+	if ( (data->pathname_slave = strdup(data->pathname_slave)) == NULL)
+		goto err_fd;
+
+	t->t_ops        = &transport_pty_operations;
+	t->private_data = data;
+
+	return 0;
+
+err_fd:
+	close_no_EINTR(data->fd);
+err_free:
+	free(data);
+err:
+	return -1;
+}
+
+struct transport *transport_pty_new(void)
+{
+	struct transport *t;
+
+	if ( (t = malloc(sizeof *t)) == NULL)
+		return NULL;
+
+	if (transport_pty_init(t) == -1) {
+		free(t);
+		return NULL;
+	}
+
+	return t;
+}
+
+static int
+transport_pty_destroy(struct transport *t)
+{
+	struct transport_pty_data *data;
+
+	assert(t != NULL);
+	assert(t->private_data != NULL);
+
+	data = t->private_data;
+	close_no_EINTR(data->fd);
+	free(data->pathname_slave);
+	free(data);
+
+	return 0;
+}
+
+static ssize_t
+transport_pty_read(struct transport *t, void *buf, size_t count)
+{
+	struct transport_pty_data *data;
+
+	assert(t != NULL);
+	assert(t->private_data != NULL);
+
+	data = t->private_data;
+	return read_no_EINTR(data->fd, buf, count);
+}
+
+static ssize_t
+transport_pty_write(struct transport *t, const void *buf, size_t count)
+{
+	struct transport_pty_data *data;
+
+	assert(t != NULL);
+	assert(t->private_data != NULL);
+
+	data = t->private_data;
+	return write_no_EINTR(data->fd, buf, count);
+}
+
+static struct transport_operations transport_pty_operations = {
+	.destroy = transport_pty_destroy,
+	.read	 = transport_pty_read,
+	.write	 = transport_pty_write
+};

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/transport-pty.h
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/transport-pty.h
@@ -1,0 +1,45 @@
+/* transport-pty.h
+ *
+ * Transport layer UNIX socket implementation.
+ *
+ * Dedicated to Yuzuyu Arielle Huizer.
+ *
+ * Copyright (C) 2016-2019  Ronald Huizer <rhuizer@hexpedition.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef TRANSPORT_PTY_H
+#define TRANSPORT_PTY_H
+
+#include <stddef.h>
+#include "transport.h"
+
+struct transport_pty_data
+{
+	int	fd;
+	char *	pathname_slave;
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int               transport_pty_init(struct transport *t);
+struct transport *transport_pty_new(void);
+
+#ifdef __cplusplus
+};
+#endif
+
+#endif

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/transport-unix.c
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/transport-unix.c
@@ -1,0 +1,188 @@
+/* transport-unix.c
+ *
+ * Transport layer UNIX socket implementation.
+ *
+ * Dedicated to Yuzuyu Arielle Huizer.
+ *
+ * Copyright (C) 2016-2019  Ronald Huizer <rhuizer@hexpedition.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include <assert.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include "transport-unix.h"
+
+static struct transport_operations transport_unix_operations;
+
+static int close_no_EINTR(int fd)
+{
+	int ret;
+
+	do {
+		ret = close(fd);
+	} while (ret == -1 && errno == EINTR);
+
+	return ret;
+}
+
+static ssize_t read_no_EINTR(int fd, void *buf, size_t count)
+{
+	ssize_t ret;
+
+	do {
+		ret = read(fd, buf, count);
+	} while (ret == -1 && errno == EINTR);
+
+	return ret;
+}
+
+static ssize_t write_no_EINTR(int fd, const void *buf, size_t count)
+{
+	ssize_t ret;
+
+	do {
+		ret = write(fd, buf, count);
+	} while (ret == -1 && errno == EINTR);
+
+	return ret;
+}
+
+int transport_unix_init(struct transport *t)
+{
+	struct transport_unix_data *data;
+
+	assert(t != NULL);
+
+	if ( (data = malloc(sizeof *data)) == NULL)
+		return -1;
+
+	if ( (data->sd = socket(AF_UNIX, SOCK_STREAM, 0)) == -1) {
+		free(data);
+		return -1;
+	}
+
+	t->t_ops        = &transport_unix_operations;
+	t->private_data = data;
+
+	return 0;
+}
+
+struct transport *transport_unix_new(void)
+{
+	struct transport *t;
+
+	if ( (t = malloc(sizeof *t)) == NULL)
+		return NULL;
+
+	if (transport_unix_init(t) == -1) {
+		free(t);
+		return NULL;
+	}
+
+	return t;
+}
+
+static int transport_unix_destroy(struct transport *t)
+{
+	struct transport_unix_data *data;
+
+	assert(t != NULL);
+	assert(t->private_data != NULL);
+
+	data = t->private_data;
+	close_no_EINTR(data->sd);
+	free(data);
+
+	return 0;
+}
+
+int transport_unix_bind(struct transport *t, const char *pathname)
+{
+	struct transport_unix_data *data;
+	struct sockaddr_un sun;
+
+	assert(t != NULL);
+	assert(t->private_data != NULL);
+
+	data = t->private_data;
+	memset(&sun, 0, sizeof sun);
+	sun.sun_family = AF_UNIX;
+
+	/* If pathname is NULL, we use auto-binding. */
+	if (pathname == NULL)
+		return bind(data->sd, (struct sockaddr *)&sun, sizeof(sa_family_t));
+
+	/* No auto-binding requested; bind the pathname. */
+	if (strlen(pathname) >= sizeof(sun.sun_path))
+		return -1;
+	strcpy(sun.sun_path, pathname);
+
+	return bind(data->sd, (struct sockaddr *)&sun, sizeof sun);
+}
+
+int transport_unix_connect(struct transport *t, const char *pathname)
+{
+	struct transport_unix_data *data;
+	struct sockaddr_un sun;
+
+	assert(t != NULL);
+	assert(t->private_data != NULL);
+	assert(pathname != NULL);
+
+	data = t->private_data;
+
+	if (strlen(pathname) >= sizeof(sun.sun_path)) {
+		errno = EOVERFLOW;
+		return -1;
+	}
+
+	memset(&sun, 0, sizeof sun);
+	sun.sun_family = AF_UNIX;
+	strcpy(sun.sun_path, pathname);
+
+	return connect(data->sd, (struct sockaddr *)&sun, sizeof sun);
+}
+
+static ssize_t transport_unix_read(struct transport *t, void *buf, size_t count)
+{
+	struct transport_unix_data *data;
+
+	assert(t != NULL);
+	assert(t->private_data != NULL);
+
+	data = t->private_data;
+	return read_no_EINTR(data->sd, buf, count);
+}
+
+static ssize_t
+transport_unix_write(struct transport *t, const void *buf, size_t count)
+{
+	struct transport_unix_data *data;
+
+	assert(t != NULL);
+	assert(t->private_data != NULL);
+
+	data = t->private_data;
+	return write_no_EINTR(data->sd, buf, count);
+}
+
+static struct transport_operations transport_unix_operations = {
+	.destroy = transport_unix_destroy,
+	.read	 = transport_unix_read,
+	.write	 = transport_unix_write
+};

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/transport-unix.h
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/transport-unix.h
@@ -1,0 +1,46 @@
+/* transport-unix.h
+ *
+ * Transport layer UNIX socket implementation.
+ *
+ * Dedicated to Yuzuyu Arielle Huizer.
+ *
+ * Copyright (C) 2016-2019  Ronald Huizer <rhuizer@hexpedition.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef TRANSPORT_UNIX_H
+#define TRANSPORT_UNIX_H
+
+#include <stddef.h>
+#include "transport.h"
+
+struct transport_unix_data
+{
+	int	sd;
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int               transport_unix_init(struct transport *t);
+struct transport *transport_unix_new(void);
+int               transport_unix_bind(struct transport *t, const char *pathname);
+int               transport_unix_connect(struct transport *t, const char *pathname);
+
+#ifdef __cplusplus
+};
+#endif
+
+#endif

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/transport.c
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/transport.c
@@ -1,0 +1,102 @@
+/* transport.c
+ *
+ * Transport layer base class.
+ *
+ * Dedicated to Yuzuyu Arielle Huizer.
+ *
+ * Copyright (C) 2016-2019  Ronald Huizer <rhuizer@hexpedition.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include <assert.h>
+#include <stdlib.h>
+#include "transport.h"
+
+int transport_destroy(struct transport *t)
+{
+	if (t->t_ops->destroy == NULL) {
+		t->error = TRANSPORT_ERROR_UNSUPPORTED;
+		return -1;
+	}
+
+	if (t->t_ops->destroy(t) == -1) {
+		t->error = TRANSPORT_ERROR_DESTROY;
+		return -1;
+	}
+
+	free(t);
+	return 0;
+}
+
+ssize_t transport_read(struct transport *t, void *buf, size_t size)
+{
+	assert(t != NULL);
+
+	if (t->t_ops->read == NULL) {
+		t->error = TRANSPORT_ERROR_UNSUPPORTED;
+		return -1;
+	}
+
+	return t->t_ops->read(t, buf, size);
+}
+
+int transport_read_all(struct transport *t, void *buf, size_t size)
+{
+	size_t total = 0;
+	ssize_t ret;
+
+	if (size == 0)
+		return 0;
+
+	do {
+		ret = transport_read(t, buf + total, size - total);
+		if (ret <= 0)
+			return -1;
+
+		total += ret;
+	} while (total != size);
+
+	return 0;
+}
+
+ssize_t transport_write(struct transport *t, const void *buf, size_t size)
+{
+	assert(t != NULL);
+
+	if (t->t_ops->write == NULL) {
+		t->error = TRANSPORT_ERROR_UNSUPPORTED;
+		return -1;
+	}
+
+	return t->t_ops->write(t, buf, size);
+}
+
+int transport_write_all(struct transport *t, const void *buf, size_t size)
+{
+	size_t total = 0;
+	ssize_t ret;
+
+	if (size == 0)
+		return 0;
+
+	do {
+		ret = transport_write(t, buf + total, size - total);
+		if (ret <= 0)
+			return -1;
+
+		total += ret;
+	} while (total != size);
+
+	return 0;
+}

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/transport.h
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s-utils/src/transport.h
@@ -1,0 +1,62 @@
+/* transport.h
+ *
+ * Transport layer base class.
+ *
+ * Dedicated to Yuzuyu Arielle Huizer.
+ *
+ * Copyright (C) 2016-2019  Ronald Huizer <rhuizer@hexpedition.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef __TRANSPORT_H
+#define __TRANSPORT_H
+
+#include <stdio.h>
+
+#define TRANSPORT_ERROR_NONE		0
+#define TRANSPORT_ERROR_UNSUPPORTED	1
+#define TRANSPORT_ERROR_DESTROY		2
+
+struct transport;
+
+struct transport_operations
+{
+	int     (*destroy)(struct transport *);
+	ssize_t (*read)(struct transport *, void *buf, size_t size);
+	ssize_t (*write)(struct transport *, const void *buf, size_t size);
+};
+
+struct transport
+{
+	int   error;
+	int   type;
+	void *private_data;
+	struct transport_operations *t_ops;
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int     transport_destroy(struct transport *t);
+ssize_t transport_read(struct transport *t, void *buf, size_t size);
+int     transport_read_all(struct transport *t, void *buf, size_t size);
+ssize_t transport_write(struct transport *t, const void *buf, size_t size);
+int     transport_write_all(struct transport *t, const void *buf, size_t size);
+
+#ifdef __cplusplus
+};
+#endif
+
+#endif

--- a/src/plugins/ds1963s_in_ds2480b/ds1963s_in_ds2480b.c
+++ b/src/plugins/ds1963s_in_ds2480b/ds1963s_in_ds2480b.c
@@ -8,11 +8,13 @@
 #include <stdlib.h>
 #include <string.h>
 #include <termios.h>
+#include <stdint.h>
 
 #include "ds1963s-device.h"
 #include "ds2480b-device.h"
 #include "transport-factory.h"
 #include "transport-pty.h"
+#include "base64.h"
 
 #include <PIUTools_SDK.h>
 
@@ -32,6 +34,13 @@ static struct transport *serial;
 struct one_wire_bus bus;
 pthread_t one_wire_thread;
 
+// static data that should be populated in the ds1963s authenticated
+// data pages upon initialization
+#define DS1963S_NUM_AUTH_DATA_PAGES 16
+#define DS1963S_AUTH_PAGE_SIZE 32
+char *static_auth_data_config_b64[DS1963S_NUM_AUTH_DATA_PAGES][128] = {0};
+uint8_t *auth_data_page_static_data[DS1963S_NUM_AUTH_DATA_PAGES] = {0};
+
 void *one_wire_loop() {
     one_wire_bus_run(&bus);
     DBG_printf("%s: one-wire thread exited\n", __FUNCTION__);
@@ -47,6 +56,23 @@ int ds1963s_open(const char *path, int flags) {
         return cur_fd;
     }
     return next_open(path, flags);
+}
+
+void _populate_auth_page_static_data(struct ds1963s_device *dev) {
+    for (int i = 0; i < DS1963S_NUM_AUTH_DATA_PAGES; i++) {
+        if (auth_data_page_static_data[i] != NULL) {
+            memcpy(&ds1963s_device->data_memory[i*32], auth_data_page_static_data[i], 32);
+        }
+    }
+}
+
+/*
+ * converts base64 data and saves it as static data for the given auth
+ * page
+ */
+void _record_auth_page_static_data(int pagenum, char *data) {
+    uint8_t *decoded_data = (uint8_t *)malloc(DS1963S_AUTH_PAGE_SIZE);
+    base64_decode(data, strlen(data), decoded_data);
 }
 
 int ds1963s_close(int fd) {
@@ -104,10 +130,39 @@ static HookEntry entries[] = {
     {}
 };
 
+static HookConfigEntry plugin_config[] = {
+    CONFIG_ENTRY("DS1963S_IN_DS2480B","authpage0",CONFIG_TYPE_STRING,static_auth_data_config_b64[0],sizeof(static_auth_data_config_b64[0])),
+    CONFIG_ENTRY("DS1963S_IN_DS2480B","authpage1",CONFIG_TYPE_STRING,static_auth_data_config_b64[1],sizeof(static_auth_data_config_b64[0])),
+    CONFIG_ENTRY("DS1963S_IN_DS2480B","authpage2",CONFIG_TYPE_STRING,static_auth_data_config_b64[2],sizeof(static_auth_data_config_b64[0])),
+    CONFIG_ENTRY("DS1963S_IN_DS2480B","authpage3",CONFIG_TYPE_STRING,static_auth_data_config_b64[3],sizeof(static_auth_data_config_b64[0])),
+    CONFIG_ENTRY("DS1963S_IN_DS2480B","authpage4",CONFIG_TYPE_STRING,static_auth_data_config_b64[4],sizeof(static_auth_data_config_b64[0])),
+    CONFIG_ENTRY("DS1963S_IN_DS2480B","authpage5",CONFIG_TYPE_STRING,static_auth_data_config_b64[5],sizeof(static_auth_data_config_b64[0])),
+    CONFIG_ENTRY("DS1963S_IN_DS2480B","authpage6",CONFIG_TYPE_STRING,static_auth_data_config_b64[6],sizeof(static_auth_data_config_b64[0])),
+    CONFIG_ENTRY("DS1963S_IN_DS2480B","authpage7",CONFIG_TYPE_STRING,static_auth_data_config_b64[7],sizeof(static_auth_data_config_b64[0])),
+    CONFIG_ENTRY("DS1963S_IN_DS2480B","authpage8",CONFIG_TYPE_STRING,static_auth_data_config_b64[8],sizeof(static_auth_data_config_b64[0])),
+    CONFIG_ENTRY("DS1963S_IN_DS2480B","authpage9",CONFIG_TYPE_STRING,static_auth_data_config_b64[9],sizeof(static_auth_data_config_b64[0])),
+    CONFIG_ENTRY("DS1963S_IN_DS2480B","authpage10",CONFIG_TYPE_STRING,static_auth_data_config_b64[10],sizeof(static_auth_data_config_b64[0])),
+    CONFIG_ENTRY("DS1963S_IN_DS2480B","authpage11",CONFIG_TYPE_STRING,static_auth_data_config_b64[11],sizeof(static_auth_data_config_b64[0])),
+    CONFIG_ENTRY("DS1963S_IN_DS2480B","authpage12",CONFIG_TYPE_STRING,static_auth_data_config_b64[12],sizeof(static_auth_data_config_b64[0])),
+    CONFIG_ENTRY("DS1963S_IN_DS2480B","authpage13",CONFIG_TYPE_STRING,static_auth_data_config_b64[13],sizeof(static_auth_data_config_b64[0])),
+    CONFIG_ENTRY("DS1963S_IN_DS2480B","authpage14",CONFIG_TYPE_STRING,static_auth_data_config_b64[14],sizeof(static_auth_data_config_b64[0])),
+    CONFIG_ENTRY("DS1963S_IN_DS2480B","authpage15",CONFIG_TYPE_STRING,static_auth_data_config_b64[15],sizeof(static_auth_data_config_b64[0])),
+    {}
+};
+
 const PHookEntry plugin_init(){
+    memset(static_auth_data_config_b64, 0x0, sizeof(static_auth_data_config_b64));
+    PIUTools_Config_Read(plugin_config);
     one_wire_bus_init(&bus);
     ds1963s_dev_init(&ds1963s);
     ds2480b_dev_init(&ds2480b);
+
+    for (int i = 0; i < DS1963S_NUM_AUTH_DATA_PAGES; i++) {
+        if (strlen(static_auth_data_config_b64[i]) > 0) {
+            _record_auth_page_static_data(i, static_auth_data_config_b64[i]);
+        }
+    }
+    _populate_auth_page_static_data(&ds1963s);
 
     if ((serial = transport_factory_new_by_name("pty")) == NULL) {
         fprintf(stderr, "ds1963s_in_ds2480b: failed to create serial transport\n");


### PR DESCRIPTION
This adds support for initializing the authenticated data pages with
static data taken as base64-encoded lines from the config file:

```
[DS1963S_IN_DS2480B]
authpage9 = UHVtcCBJdCBVcCBQcm8=
```

This also vendors ds1963s-utils as part of the main tree instead of as a submodule with a few changes to get it to compile in the expected environment (older gcc, no valgrind)