### PR TITLE
disable AppArmor to prevent permission errors when mounting squashfs

### DIFF
--- a/ext/run_container.sh
+++ b/ext/run_container.sh
@@ -111,6 +111,8 @@ else
     docker_args+=" -e PULSE_SERVER=unix:${XDG_RUNTIME_DIR}/pulse/native -v /run/user/$(id -u):/run/user/$(id -u) --group-add $(getent group audio | cut -d: -f3)"
 fi
 
+# Disable AppArmor to prevent permission issues
+docker_args+=" --cap-add SYS_ADMIN --device /dev/fuse --security-opt apparmor:unconfined"
 
 # ---- END WSL ----
 # Add Our PIUTools Mounts


### PR DESCRIPTION
fixes:
![image](https://github.com/pumpitupdev/piutools/assets/99104347/8c8daad0-7bc3-49fb-aa2d-1fa2e52076ad)
