### PR TITLE
Add IDA remote debug server support

### DIFF
--- a/ext/run_container.sh
+++ b/ext/run_container.sh
@@ -140,7 +140,8 @@ docker_args+=" -e RUN_GAME=1"
 #docker_args+=" -e RUN_LTRACE=1"
 
 # Enable IDA remote debug server. 
-# You must place your own IDA remote debug server executable named 'linux_server64' in the tools folder. Default port is 23946.
+# You must place your own IDA remote debug server executable named 'linux_server64' in the tools folder. 
+# Use 'host.docker.internal' as the hostname in IDA and the default port of 23946.
 #docker_args+=" -e RUN_IDA_DBG_SERVER=1"
 #docker_args+=" -p 23946:23946"
 

--- a/ext/run_container.sh
+++ b/ext/run_container.sh
@@ -139,6 +139,11 @@ docker_args+=" -e RUN_GAME=1"
 #docker_args+=" -e RUN_STRACE=1"
 #docker_args+=" -e RUN_LTRACE=1"
 
+# Enable IDA remote debug server. 
+# You must place your own IDA remote debug server executable named 'linux_server64' in the tools folder. Default port is 23946.
+#docker_args+=" -e RUN_IDA_DBG_SERVER=1"
+#docker_args+=" -p 23946:23946"
+
 docker_args+=" pumpos_classic $piutools_bin/tools/bootstrap_game.sh"
 
 echo $docker_args

--- a/ext/tools/bootstrap_game.sh
+++ b/ext/tools/bootstrap_game.sh
@@ -57,6 +57,11 @@ if [ -d "$PIUTOOLS_ROM_PATH/libs" ]; then
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PIUTOOLS_ROM_PATH/libs
 fi
 
+# Runs a IDA remote debug server.
+if [ -n "$RUN_IDA_DBG_SERVER" ]; then
+	$PIUTOOLS_PATH/tools/linux_server64 &
+fi
+
 # Based on the command, we have a few execution options.
 if [ -n "$RUN_GDB" ]; then
   unset LD_PRELOAD


### PR DESCRIPTION
Pass RUN_IDA_DBG_SERVER to Docker to run an IDA remote debug server

![image](https://github.com/pumpitupdev/piutools/assets/99104347/658cf9dc-4816-4b4c-a9f5-54ab2164ec9e)
![image](https://github.com/pumpitupdev/piutools/assets/99104347/baa87e4a-c88b-4208-81cd-382be50ff5dd)
![image](https://github.com/pumpitupdev/piutools/assets/99104347/b3b25139-193a-4b76-9b29-7bd2f2b1b279)
